### PR TITLE
Switch argument in idl method Graph::getErroConfigForNode

### DIFF
--- a/idl/hpp/corbaserver/manipulation/graph.idl
+++ b/idl/hpp/corbaserver/manipulation/graph.idl
@@ -184,14 +184,14 @@ module hpp {
 
 	/// Get error of a config with respect to a node constraint
 	///
-	/// \param config Configuration,
 	/// \param nodeId id of the node.
+	/// \param config Configuration,
 	/// \retval error the error of the node constraint for the
 	///        configuration
 	/// \return whether the configuration belongs to the node.
 	/// Call method core::ConstraintSet::isSatisfied for the node
 	/// constraints.
-	boolean getConfigErrorForNode (in floatSeq config, in ID nodeId,
+	boolean getConfigErrorForNode (in ID nodeId, in floatSeq config,
 				       out floatSeq errorVector) raises (Error);
 
 	/// Print set of constraints relative to a node in a string

--- a/src/graph.impl.cc
+++ b/src/graph.impl.cc
@@ -600,7 +600,7 @@ namespace hpp {
       }
 
       CORBA::Boolean Graph::getConfigErrorForNode
-      (const hpp::floatSeq& dofArray, ID nodeId, hpp::floatSeq_out error)
+      (ID nodeId, const hpp::floatSeq& dofArray, hpp::floatSeq_out error)
 	throw (hpp::Error)
       {
 	graph::NodePtr_t node = getComp <graph::Node> (nodeId);

--- a/src/graph.impl.hh
+++ b/src/graph.impl.hh
@@ -139,7 +139,7 @@ namespace hpp {
             throw (hpp::Error);
 
 	virtual CORBA::Boolean getConfigErrorForNode
-	(const hpp::floatSeq& dofArray, ID nodeId, hpp::floatSeq_out error)
+	(ID nodeId, const hpp::floatSeq& dofArray, hpp::floatSeq_out error)
 	  throw (hpp::Error);
 
 	virtual void displayNodeConstraints

--- a/src/hpp/corbaserver/manipulation/constraint_graph.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph.py
@@ -431,16 +431,16 @@ class ConstraintGraph (object):
 
     ## Get error of a config with respect to a node constraint
     #
-    #  \param config Configuration,
     #  \param node name of the node.
+    #  \param config Configuration,
     #  \retval error the error of the node constraint for the
     #         configuration
     #  \return whether the configuration belongs to the node.
     #  Call method core::ConstraintSet::isSatisfied for the node
     #  constraints.
-    def getConfigErrorForNode (self, config, nodeId) :
+    def getConfigErrorForNode (self, nodeId, config) :
         return self.client.graph.getConfigErrorForNode \
-          (config, self.nodes [nodeId])
+          (self.nodes [nodeId], config)
 
     ## Print set of constraints relative to a node in a string
     #


### PR DESCRIPTION
As this method is essentially used for debugging via python, I did not work on retro-compatibility.
This PR also adds an idl interface to evaluate the error of a config with respect to edge constraints.