### PR TITLE
Add class Constraints to homogeneize various types of constraints

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,6 +130,7 @@ INSTALL(
   ${CMAKE_CURRENT_SOURCE_DIR}/hpp/corbaserver/manipulation/client.py
   ${CMAKE_CURRENT_SOURCE_DIR}/hpp/corbaserver/manipulation/problem_solver.py
   ${CMAKE_CURRENT_SOURCE_DIR}/hpp/corbaserver/manipulation/robot.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/hpp/corbaserver/manipulation/constraints.py
   ${CMAKE_CURRENT_SOURCE_DIR}/hpp/corbaserver/manipulation/constraint_graph.py
   DESTINATION ${PYTHON_SITELIB}/hpp/corbaserver/manipulation
   )

--- a/src/hpp/corbaserver/manipulation/__init__.py
+++ b/src/hpp/corbaserver/manipulation/__init__.py
@@ -9,3 +9,4 @@ import robot_idl
 from client import Client
 from problem_solver import ProblemSolver
 from constraint_graph import ConstraintGraph
+from constraints import Constraints

--- a/src/hpp/corbaserver/manipulation/constraints.py
+++ b/src/hpp/corbaserver/manipulation/constraints.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2014 CNRS
+# Author: Joseph Mirabel
+#
+# This file is part of hpp-manipulation-corba.
+# hpp-manipulation-corba is free software: you can redistribute it
+# and/or modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation, either version
+# 3 of the License, or (at your option) any later version.
+#
+# hpp-manipulation-corba is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Lesser Public License for more details.  You should have
+# received a copy of the GNU Lesser General Public License along with
+# hpp-manipulation-corba.  If not, see
+# <http://www.gnu.org/licenses/>.
+
+
+class Constraints (object):
+    """
+    Store constraints of various types
+
+      - grasps,
+      - pregrasps.
+      - numerical constraints,
+      - lockedJoints
+    """
+    def __init__ (self, grasps = [], pregrasps = [], numConstraints = [],
+                  lockedJoints = []):
+        if type (grasps) is str:
+            raise TypeError ("argument grasps should be a list of strings")
+        if type (pregrasps) is str:
+            raise TypeError ("argument pregrasps should be a list of strings")
+        if type (numConstraints) is str:
+            raise TypeError \
+                ("argument numConstraints should be a list of strings")
+        if type (lockedJoints) is str:
+            raise TypeError \
+                ("argument lockedJoints should be a list of strings")
+        self._grasps = set (grasps)
+        self._pregrasps = set (pregrasps)
+        self._numConstraints = set (numConstraints)
+        self._lockedJoints = set (lockedJoints)
+
+    def __add__ (self, other):
+        res = Constraints (grasps = self._grasps.union (other._grasps),
+                           pregrasps = self._pregrasps.union \
+                           (other._pregrasps),
+                           numConstraints = self._numConstraints.union \
+                           (other._numConstraints),
+                           lockedJoints = self._lockedJoints.union \
+                           (other._lockedJoints))
+        return res
+
+    def __sub__ (self, other):
+        res = Constraints (grasps = self._grasps - other._grasps,
+                           pregrasps = self._pregrasps - other._pregrasps,
+                           numConstraints = self._numConstraints - \
+                           other._numConstraints,
+                           lockedJoints = self._lockedJoints - \
+                           other._lockedJoints)
+        return res
+
+    @property
+    def grasps (self):
+        return list (self._grasps)
+
+    @property
+    def pregrasps (self):
+        return list (self._pregrasps)
+
+    @property
+    def numConstraints (self):
+        return list (self._numConstraints)
+
+    @property
+    def lockedJoints (self):
+        return list (self._lockedJoints)
+
+    def __str__ (self):
+        res = "constraints\n"
+        res += "  grasps: "
+        for c in self._grasps:
+            res += c + ', '
+        res += "\n  pregrasps: "
+        for c in self._pregrasps:
+            res += c + ', '
+        res += "\n  numConstraints: "
+        for c in self._numConstraints:
+            res += c + ', '
+        res += "\n  lockedJoints: "
+        for c in self._lockedJoints:
+            res += c + ', '
+        return res


### PR DESCRIPTION
  - ContraintGraph.setConstraints now takes as parameter an instance of
    Constraints containing grasps, pregrasps, numerical constraints, locked
    joints.
  - calling the method with old parameters raises a warning.