### PR TITLE
Graph.initialize + others.

### DIFF
--- a/idl/hpp/corbaserver/manipulation/graph.idl
+++ b/idl/hpp/corbaserver/manipulation/graph.idl
@@ -264,6 +264,9 @@ module hpp {
         void setShort (in ID edgeId, in boolean isShort)
           raises (Error);
 
+        boolean isShort (in ID edgeId)
+          raises (Error);
+
 	/// Automatically build a constraint graph
 	///
 	/// \param graphName name of the graph,

--- a/idl/hpp/corbaserver/manipulation/graph.idl
+++ b/idl/hpp/corbaserver/manipulation/graph.idl
@@ -318,7 +318,12 @@ module hpp {
         long getWeight (in ID edgeID)
           raises (Error);
 
-        void getRelativeMotionMatrix (in ID edgeID, out intSeqSeq matrix);
+        /// This must be called when the graph has been built.
+        void initialize ()
+          raises (Error);
+
+        void getRelativeMotionMatrix (in ID edgeID, out intSeqSeq matrix)
+          raises (Error);
       }; // interface Graph
     }; // module manipulation
   }; // module corbaserver

--- a/idl/hpp/corbaserver/manipulation/problem.idl
+++ b/idl/hpp/corbaserver/manipulation/problem.idl
@@ -34,6 +34,9 @@ module hpp {
         /// \return true if a new problem was created.
         boolean selectProblem (in string name) raises (Error);
 
+        /// Reset the current problem.
+        void resetProblem () raises (Error);
+
         /// Return a list of available elements of type type
         /// \param type enter "type" to know what types I know of.
         ///             This is case insensitive.

--- a/idl/hpp/corbaserver/manipulation/problem.idl
+++ b/idl/hpp/corbaserver/manipulation/problem.idl
@@ -203,6 +203,11 @@ module hpp {
         /// \warning when setTargetState is called, goal configurations are
         ///          ignored.
         void setTargetState(in ID IDstate) raises (Error);
+
+        /// Get the edge ID of the motion that generated the configuration
+        /// at the given parameter.
+        ID edgeAtParam (in unsigned short inPathId, in double atDistance)
+          raises (Error);
       }; // interface Problem
     }; // module manipulation
   }; // module corbaserver

--- a/idl/hpp/corbaserver/manipulation/robot.idl
+++ b/idl/hpp/corbaserver/manipulation/robot.idl
@@ -89,6 +89,20 @@ module hpp
         in string srdfSuffix)
       raises (Error);
 
+    ///  Insert humanoid robot model as a child of the root joint of the Device
+    ///
+    /// \param robotName key of the robot in ProblemSolver object map
+    ///        (see hpp::manipulation::ProblemSolver::addRobot)
+    /// \param rootJointType type of root joint among "anchor", "freeflyer",
+    /// "planar",
+    /// \param urdfString urdf file,
+    /// \param srdfString srdf file. Can be empty.
+    ///
+    void insertHumanoidModelFromString (in string robotName, in string rootJointType,
+        in string urdfString, in string srdfString)
+      raises (Error);
+
+
     ///  Load object model and store in local map
     ///
     /// \param robotName key of the object in ProblemSolver object map

--- a/idl/hpp/corbaserver/manipulation/robot.idl
+++ b/idl/hpp/corbaserver/manipulation/robot.idl
@@ -52,6 +52,18 @@ module hpp
         in string srdfSuffix)
       raises (Error);
 
+    ///  Insert robot model as a child of the root joint of the Device
+    ///
+    /// \param robotName key of the robot in ProblemSolver object map
+    ///        (see hpp::manipulation::ProblemSolver::addRobot)
+    /// \param rootJointType type of root joint among "anchor", "freeflyer",
+    /// "planar",
+    /// \param urdfString urdf file,
+    /// \param srdfString srdf file. Can be empty.
+    void insertRobotModelFromString (in string robotName, in string rootJointType,
+        in string urdfString, in string srdfString)
+      raises (Error);
+
     /// Load a SRDF for the robot. Several SRDF can thus be loaded for the same
     /// robot
     void insertRobotSRDFModel (in string robotName, in string packageName,

--- a/src/graph.impl.cc
+++ b/src/graph.impl.cc
@@ -443,7 +443,7 @@ namespace hpp {
             edge->insertParamConstraint (problemSolver()->PsC_t::get <LockedJointPtr_t> (name));
           }
 
-          edge->buildHistogram ();
+          // edge->buildHistogram ();
         } catch (std::exception& err) {
           throw Error (err.what());
         }
@@ -674,7 +674,6 @@ namespace hpp {
 	}
       }
 
-
       void Graph::displayNodeConstraints
       (hpp::ID nodeId, CORBA::String_out constraints) throw (Error)
       {
@@ -818,6 +817,16 @@ namespace hpp {
         graph::EdgePtr_t edge = getComp <graph::Edge> (edgeId);
         try {
           return (Long) edge->from ()->getWeight (edge);
+	} catch (const std::exception& exc) {
+	  throw Error (exc.what ());
+	}
+      }
+
+      void Graph::initialize ()
+        throw (hpp::Error)
+      {
+        try {
+          problemSolver ()->initConstraintGraph ();
 	} catch (const std::exception& exc) {
 	  throw Error (exc.what ());
 	}

--- a/src/graph.impl.cc
+++ b/src/graph.impl.cc
@@ -764,6 +764,17 @@ namespace hpp {
 	}
       }
 
+      bool Graph::isShort (ID edgeId)
+        throw (hpp::Error)
+      {
+        graph::EdgePtr_t edge = getComp <graph::Edge> (edgeId);
+        try {
+          return edge->isShort ();
+	} catch (const std::exception& exc) {
+	  throw Error (exc.what ());
+	}
+      }
+
       intSeq* Graph::autoBuild (
           const char* graphName,
           const Names_t& grippers,

--- a/src/graph.impl.hh
+++ b/src/graph.impl.hh
@@ -173,6 +173,9 @@ namespace hpp {
           virtual void setShort (ID edgeId, CORBA::Boolean isShort)
             throw (hpp::Error);
 
+          virtual bool isShort (ID edgeId)
+            throw (hpp::Error);
+
           virtual intSeq* autoBuild (const char* graphName,
               const Names_t& grippers, const Names_t& objects,
               const Namess_t& handlesPerObject, const Namess_t& shapesPreObject,

--- a/src/graph.impl.hh
+++ b/src/graph.impl.hh
@@ -185,6 +185,9 @@ namespace hpp {
           virtual Long getWeight (ID edgeId)
             throw (hpp::Error);
 
+          virtual void initialize ()
+            throw (hpp::Error);
+
           virtual void getRelativeMotionMatrix (ID edgeID, intSeqSeq_out matrix)
             throw (hpp::Error);
 

--- a/src/hpp/corbaserver/manipulation/__init__.py
+++ b/src/hpp/corbaserver/manipulation/__init__.py
@@ -7,6 +7,6 @@ import problem_idl
 import robot_idl
 
 from client import Client
-from problem_solver import ProblemSolver
+from problem_solver import ProblemSolver, newProblem
 from constraint_graph import ConstraintGraph
 from constraints import Constraints

--- a/src/hpp/corbaserver/manipulation/constraint_graph.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph.py
@@ -600,6 +600,9 @@ class ConstraintGraph (object):
                 (name, grippers, objects, handlesPerObjects, shapesPerObjects, envNames, rules)
         return ConstraintGraph (robot, name, makeGraph = False);
 
+    def initialize (self):
+        self.graph.initialize()
+
     ##
     # \}
 

--- a/src/hpp/corbaserver/manipulation/constraint_graph.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph.py
@@ -148,6 +148,9 @@ class ConstraintGraph (object):
     def setShort (self, edge, isShort) :
       return self.client.graph.setShort (self.edges [edge], isShort)
 
+    def isShort (self, edge) :
+      return self.client.graph.isShort (self.edges [edge])
+
     ### Create a WaypointEdge.
     ## \param nodeFrom, nodeTo, name, weight, isInNode see createEdge note,
     ## \param nb number of waypoints,

--- a/src/hpp/corbaserver/manipulation/constraint_graph.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph.py
@@ -601,7 +601,9 @@ class ConstraintGraph (object):
     def buildGenericGraph (robot, name, grippers, objects, handlesPerObjects, shapesPerObjects, envNames, rules = []):
         robot.client.manipulation.graph.autoBuild \
                 (name, grippers, objects, handlesPerObjects, shapesPerObjects, envNames, rules)
-        return ConstraintGraph (robot, name, makeGraph = False);
+        graph = ConstraintGraph (robot, name, makeGraph = False); 
+        graph.initialize()
+        return graph
 
     def initialize (self):
         self.graph.initialize()

--- a/src/hpp/corbaserver/manipulation/problem_solver.py
+++ b/src/hpp/corbaserver/manipulation/problem_solver.py
@@ -611,6 +611,13 @@ class ProblemSolver (object):
     def erasePath (self, pathId):
         return self.client.basic.problem.erasePath (pathId)
 
+    ## Concatenate two paths
+    # The function appends the second path to the first one
+    # and remove the second path.
+    def concatenatePath (self, pathId1, pathId2):
+        return self.client.basic.problem.concatenatePath (pathId1, pathId2)
+
+
     ## \name Interruption of a path planning request
     #  \{
 

--- a/src/hpp/corbaserver/manipulation/problem_solver.py
+++ b/src/hpp/corbaserver/manipulation/problem_solver.py
@@ -555,6 +555,21 @@ class ProblemSolver (object):
         return self.client.basic.problem.selectPathProjector \
             (pathProjectorType, tolerance)
 
+    ##  Select distance type
+    #   \param Name of the distance type, either
+    #      "WeighedDistance" or any type added by method
+    #      core::ProblemSolver::addDistanceType
+    def selectDistance (self, distanceType):
+        return self.client.basic.problem.selectDistance (distanceType)
+
+
+    ##  Select steering method type
+    #   \param Name of the steering method type, either
+    #      "SteeringMethodStraight" or any type added by method
+    #      core::ProblemSolver::addSteeringMethodType
+    def selectSteeringMethod (self, steeringMethodType):
+        return self.client.basic.problem.selectSteeringMethod (steeringMethodType)
+
     def prepareSolveStepByStep (self):
         return self.client.basic.problem.prepareSolveStepByStep ()
 
@@ -578,6 +593,12 @@ class ProblemSolver (object):
     def directPath (self, startConfig, endConfig, validate):
         return self.client.basic.problem.directPath (startConfig, endConfig,
                                                      validate)
+
+    ## Project path using the path projector.
+    # \return True in case of success, False otherwise.
+    def projectPath (self, pathId):
+        return self.client.basic.problem.projectPath (pathId)
+
 
     ## Get Number of paths
     def numberPaths (self):

--- a/src/hpp/corbaserver/manipulation/problem_solver.py
+++ b/src/hpp/corbaserver/manipulation/problem_solver.py
@@ -23,6 +23,11 @@ except ImportError:
     hpp=None
     pass
 
+def newProblem ():
+    from hpp.corbaserver.manipulation import Client
+    cl = Client()
+    cl.problem.resetProblem()
+
 ## Definition of a manipulation planning problem
 #
 #  This class wraps the Corba client to the server implemented by

--- a/src/hpp/corbaserver/manipulation/robot.py
+++ b/src/hpp/corbaserver/manipulation/robot.py
@@ -50,12 +50,16 @@ class Robot (object):
     # \param load whether to actually load urdf files. Set to no if you only
     #        want to initialize a corba client to an already initialized
     #        problem.
-    def __init__ (self, compositeName, robotName, rootJointType, load = True):
+    def __init__ (self, compositeName = None, robotName = None, rootJointType = None, load = True):
         self.tf_root = "base_link"
         self.rootJointType = dict()
-        self.name = compositeName
-        self.displayName = robotName
         self.client = CorbaClient ()
+        if compositeName is None:
+            self.name = self.client.basic.robot.getRobotName()
+            load = False
+        else:
+            self.name = compositeName
+        self.displayName = robotName
         self.load = load
         self.loadModel (robotName, rootJointType)
 
@@ -178,10 +182,6 @@ class Robot (object):
     ## Rebuild inner variables rankInConfiguration and rankInVelocity
     def rebuildRanks (self):
         self.jointNames = self.client.basic.robot.getJointNames ()
-        self.__setattr__ (self.displayName + 'JointNames',
-                          map (lambda n : n [len(self.displayName)+1:],
-                               filter (lambda n: n[:len (self.displayName)]
-                                       == self.displayName, self.jointNames)))
         self.rankInConfiguration = dict ()
         self.rankInVelocity = dict ()
         rankInConfiguration = rankInVelocity = 0
@@ -253,17 +253,6 @@ class Robot (object):
     ##        initial configuration.
     def setRootJointPosition (self, robotName, position):
         return self.client.manipulation.robot.setRootJointPosition (robotName, position)
-
-    ## Set bounds on the translation part of the freeflyer joint.
-    #
-    #  Valid only if the robot has a freeflyer joint.
-    def setTranslationBounds (self, xmin, xmax, ymin, ymax, zmin, zmax):
-        self.client.basic.robot.setJointBounds \
-            (self.displayName + "base_joint_x", [xmin, xmax])
-        self.client.basic.robot.setJointBounds \
-            (self.displayName + "base_joint_y", [ymin, ymax])
-        self.client.basic.robot.setJointBounds \
-            (self.displayName + "base_joint_z", [zmin, zmax])
 
     ## Get link position in joint frame
     #

--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -594,6 +594,39 @@ namespace hpp {
           throw hpp::Error (exc.what ());
         }
       }
+
+      ID Problem::edgeAtParam (UShort pathId, Double param)
+        throw (Error)
+      {
+	try {
+	  if (pathId >= problemSolver()->paths ().size ()) {
+            HPP_THROW (Error, "Wrong path id: " << pathId << ", number path: "
+		<< problemSolver()->paths ().size () << ".");
+	  }
+          core::PathVectorPtr_t path = problemSolver()->paths () [pathId];
+          core::PathVectorPtr_t flat = core::PathVector::create(path->outputSize(), path->outputDerivativeSize());
+          path->flatten(flat);
+          value_type unused;
+          std::size_t r = flat->rankAtParam(param, unused);
+          PathPtr_t p = flat->pathAtRank (r);
+          manipulation::ConstraintSetPtr_t constraint = 
+            HPP_DYNAMIC_PTR_CAST (manipulation::ConstraintSet, p->constraints());
+          if (!constraint) {
+            HPP_THROW (Error, "Path constraint is not of the good type "
+                << "at id " << pathId << ", param " << param
+                << " (rank: " << r << ")");
+          }
+          if (!constraint->edge()) {
+            HPP_THROW (Error, "Path constraint does not contain edge information "
+                << "at id " << pathId << ", param " << param
+                << " (rank: " << r << ")");
+          }
+          return (ID)constraint->edge()->id();
+	}
+	catch (const std::exception& exc) {
+	  throw hpp::Error (exc.what ());
+	}
+      }
     } // namespace impl
   } // namespace manipulation
 } // namespace hpp

--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -174,26 +174,9 @@ namespace hpp {
 				 const char* handleName)
 	throw (hpp::Error)
       {
-	DevicePtr_t robot = getRobotOrThrow (problemSolver());
-	hppDout (info, *robot);
 	try {
-          GripperPtr_t gripper = robot->get <GripperPtr_t> (gripperName);
-	  if (!gripper) {
-	    std::string msg (std::string ("No gripper with name ") +
-			     std::string (gripperName) + std::string ("."));
-	    throw std::runtime_error (msg.c_str ());
-	  }
-          HandlePtr_t handle = robot->get <HandlePtr_t> (handleName);
-	  if (!handle) {
-	    std::string msg (std::string ("No handle with name ") +
-			     std::string (handleName) + std::string ("."));
-	    throw std::runtime_error (msg.c_str ());
-	  }
-	  NumericalConstraintPtr_t constraint (handle->createGrasp (gripper));
-	  NumericalConstraintPtr_t complement
-	    (handle->createGraspComplement (gripper));
-	  problemSolver()->addNumericalConstraint (graspName, constraint);
-	  problemSolver()->addNumericalConstraint (std::string(graspName) + "/complement", complement);
+          problemSolver()->createGraspConstraint
+            (graspName, gripperName, handleName);
 	} catch (const std::exception& exc) {
 	  throw Error (exc.what ());
 	}
@@ -204,15 +187,9 @@ namespace hpp {
                                     const char* handleName)
 	throw (hpp::Error)
       {
-        DevicePtr_t robot = getRobotOrThrow (problemSolver());
 	try {
-          const GripperPtr_t gripper = robot->get <GripperPtr_t> (gripperName);
-          const HandlePtr_t& handle = robot->get <HandlePtr_t> (handleName);
-          std::string name (graspName);
-          value_type c = handle->clearance () + gripper->clearance ();
-	  NumericalConstraintPtr_t constraint =
-	    handle->createPreGrasp (gripper, c);
-	  problemSolver()->addNumericalConstraint (name, constraint);
+          problemSolver()->createPreGraspConstraint
+            (graspName, gripperName, handleName);
 	} catch (const std::exception& exc) {
 	  throw Error (exc.what ());
 	}

--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -132,6 +132,7 @@ namespace hpp {
       void Problem::resetProblem () throw (hpp::Error)
       {
         corbaServer::ProblemSolverMapPtr_t psMap (server_->problemSolverMap());
+        delete psMap->map_ [ psMap->selected_ ];
         psMap->map_ [ psMap->selected_ ]
           = manipulation::ProblemSolver::create ();
       }

--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -129,6 +129,13 @@ namespace hpp {
         return !has;
       }
 
+      void Problem::resetProblem () throw (hpp::Error)
+      {
+        corbaServer::ProblemSolverMapPtr_t psMap (server_->problemSolverMap());
+        psMap->map_ [ psMap->selected_ ]
+          = manipulation::ProblemSolver::create ();
+      }
+
       Names_t* Problem::getAvailable (const char* what) throw (hpp::Error)
       {
         std::string w (what);

--- a/src/problem.impl.hh
+++ b/src/problem.impl.hh
@@ -41,6 +41,8 @@ namespace hpp {
 
         virtual bool selectProblem (const char* name) throw (hpp::Error);
 
+        virtual void resetProblem () throw (hpp::Error);
+
         virtual Names_t* getAvailable (const char* what) throw (hpp::Error);
 
         virtual void createGrasp (const char* graspName,

--- a/src/problem.impl.hh
+++ b/src/problem.impl.hh
@@ -104,6 +104,9 @@ namespace hpp {
 
         virtual void setTargetState (hpp::ID IDstate);
 
+        virtual ID edgeAtParam (UShort pathId, Double param)
+          throw (Error);
+
       private:
         ProblemSolverPtr_t problemSolver();
         graph::GraphPtr_t graph(bool throwIfNull = true);

--- a/src/robot.impl.cc
+++ b/src/robot.impl.cc
@@ -394,6 +394,7 @@ namespace hpp {
           Transform3f T;
           hppTransformToTransform3f (position, T);
           robot->setRobotRootPosition(n, T);
+          robot->computeForwardKinematics();
         } catch (const std::exception& exc) {
           throw Error (exc.what ());
         }

--- a/src/robot.impl.cc
+++ b/src/robot.impl.cc
@@ -231,6 +231,27 @@ namespace hpp {
 	}
       }
 
+      void Robot::insertHumanoidModelFromString (const char* robotName,
+          const char* rootJointType,
+          const char* urdfString,
+          const char* srdfString)
+	throw (Error)
+      {
+	try {
+          DevicePtr_t robot = getOrCreateRobot (problemSolver());
+          if (robot->has<FrameIndexes_t> (robotName))
+            HPP_THROW(std::invalid_argument, "A robot named " << robotName << " already exists");
+          pinocchio::urdf::loadModelFromString (robot, 0, robotName,
+              rootJointType, urdfString, srdfString);
+          pinocchio::urdf::setupHumanoidRobot (robot, robotName);
+	  srdf::loadModelFromXML (robot, robotName, srdfString);
+          robot->didInsertRobot (robotName);
+          problemSolver()->resetProblem ();
+	} catch (const std::exception& exc) {
+	  throw Error (exc.what ());
+	}
+      }
+
       void Robot::loadEnvironmentModel (const char* package,
           const char* envModelName, const char* urdfSuffix,
           const char* srdfSuffix, const char* prefix)

--- a/src/robot.impl.hh
+++ b/src/robot.impl.hh
@@ -69,6 +69,12 @@ namespace hpp {
               const char* srdfSuffix)
             throw (hpp::Error);
 
+          virtual void insertHumanoidModelFromString (const char* robotName,
+              const char* rootJointType,
+              const char* urdfString,
+              const char* srdfString)
+            throw (hpp::Error);
+
           virtual void loadEnvironmentModel (const char* package,
               const char* envModelName, const char* urdfSuffix,
               const char* srdfSuffix, const char* prefix)

--- a/src/robot.impl.hh
+++ b/src/robot.impl.hh
@@ -46,6 +46,12 @@ namespace hpp {
               const char* srdfSuffix)
             throw (hpp::Error);
 
+          virtual void insertRobotModelFromString (const char* robotName,
+              const char* rootJointType,
+              const char* urdfString,
+              const char* srdfString)
+            throw (hpp::Error);
+
           virtual void insertRobotSRDFModel (const char* robotName,
               const char* packageName, const char* modelName,
               const char* srdfSuffix)
@@ -66,6 +72,10 @@ namespace hpp {
           virtual void loadEnvironmentModel (const char* package,
               const char* envModelName, const char* urdfSuffix,
               const char* srdfSuffix, const char* prefix)
+            throw (hpp::Error);
+
+          virtual void loadEnvironmentModelFromString (const char* urdfString,
+              const char* srdfString, const char* prefix)
             throw (hpp::Error);
 
           virtual Transform__slice* getRootJointPosition (const char* robotName)


### PR DESCRIPTION
The main change is that now, the graph must be explicitly initialized when ready (in Python, `graph.initialize`).

When the graph is not initialized, the user gets an exception so old script should be easily fixed.