### PR TITLE
Do not copy NumericalConstraint

### DIFF
--- a/src/graph.impl.cc
+++ b/src/graph.impl.cc
@@ -494,9 +494,7 @@ namespace hpp {
               if (!problemSolver()->numericalConstraint (name))
                 throw Error ("The numerical function does not exist.");
               component->addNumericalConstraint
-		(HPP_STATIC_PTR_CAST
-		 (NumericalConstraint,
-		  problemSolver()->numericalConstraint(name)->copy ()),
+		(problemSolver()->numericalConstraint(name),
 		 problemSolver()->passiveDofs (pdofNames [i]));
             }
           } catch (std::exception& err) {


### PR DESCRIPTION
I do not remember the reason for that copy but I think it is not necessary anymore.

The reason might have been the right hand side. If it was so, it isn't needed anymore.