### PR TITLE
Add IDL for steeringMethod::EndEffectorTrajectory 

### DIFF
--- a/idl/hpp/manipulation_idl/steering_methods.idl
+++ b/idl/hpp/manipulation_idl/steering_methods.idl
@@ -1,0 +1,36 @@
+// Copyright (c) 2019, LAAS-CNRS
+// Authors: Joseph Mirabel (joseph.mirabel@laas.fr)
+//
+// This file is part of hpp-manipulation-corba.
+// hpp-manipulation-corba is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// hpp-manipulation-corba is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// hpp-manipulation-corba. If not, see <http://www.gnu.org/licenses/>.
+
+
+#ifndef HPP_MANIPULATION_STEERING_METHODS_IDL
+#define HPP_MANIPULATION_STEERING_METHODS_IDL
+
+#include "hpp/corbaserver/manipulation/gcommon.idl"
+#include <hpp/common.idl>
+#include <hpp/constraints_idl/constraints.idl>
+#include <hpp/core_idl/steering_methods.idl>
+
+module hpp {
+  module manipulation_idl {
+  interface EndEffectorTrajectory : core_idl::SteeringMethod
+  {
+    void trajectoryConstraint (in constraints_idl::Implicit c) raises (Error);
+    void trajectory (in core_idl::Path eeTraj, in boolean se3Output) raises (Error);
+  }; // interface SteeringMethod
+  }; // module manipulation
+}; // module hpp
+
+#endif // HPP_MANIPULATION_STEERING_METHODS_IDL

--- a/include/hpp/manipulation_idl/steering-methods.hh
+++ b/include/hpp/manipulation_idl/steering-methods.hh
@@ -1,0 +1,67 @@
+// Copyright (C) 2019 by Joseph Mirabel, LAAS-CNRS.
+//
+// This file is part of the hpp-corbaserver.
+//
+// This software is provided "as is" without warranty of any kind,
+// either expressed or implied, including but not limited to the
+// implied warranties of fitness for a particular purpose.
+//
+// See the COPYING file for more information.
+
+#ifndef HPP_MANIPULATION_IDL_STEERING_METHODS_HH
+# define HPP_MANIPULATION_IDL_STEERING_METHODS_HH
+
+# include <vector>
+# include <stdlib.h>
+
+# include <hpp/manipulation/steering-method/end-effector-trajectory.hh>
+
+# include <hpp/corbaserver/fwd.hh>
+# include <hpp/corbaserver/conversions.hh>
+# include <hpp/corbaserver/constraints_idl/constraints.hh>
+# include <hpp/corbaserver/core_idl/steering-methods.hh>
+# include <hpp/manipulation_idl/steering_methods-idl.hh>
+
+# include "hpp/corbaserver/servant-base.hh"
+
+namespace hpp
+{
+  namespace corbaServer
+  {
+    namespace manipulation_idl
+    {
+      template <typename _Base, typename _Storage>
+      class EndEffectorTrajectoryServant : public core_idl::SteeringMethodServant<_Base, _Storage>
+      {
+          SERVANT_BASE_TYPEDEFS(hpp::manipulation_idl::EndEffectorTrajectory, core::SteeringMethod);
+
+        public:
+          typedef core_idl::SteeringMethodServant<Base, Storage> Parent;
+
+          EndEffectorTrajectoryServant (Server* server, const Storage& s) :
+            Parent (server, s) {}
+
+          virtual ~EndEffectorTrajectoryServant () {}
+
+          void trajectoryConstraint (hpp::constraints_idl::Implicit_ptr c) throw (Error)
+          {
+            constraints::ImplicitPtr_t cc =
+              reference_to_servant_base<constraints::Implicit>(server_, c)->get();
+            getT()->trajectoryConstraint (cc);
+          }
+
+          void trajectory (hpp::core_idl::Path_ptr eeTraj, CORBA::Boolean se3Output) throw (Error)
+          {
+            core::PathPtr_t path =
+              reference_to_servant_base<core::Path>(server_, eeTraj)->get();
+            getT()->trajectory (path, se3Output);
+          }
+      };
+
+      typedef EndEffectorTrajectoryServant<POA_hpp::manipulation_idl::EndEffectorTrajectory,
+              core_idl::SteeringMethodStorage<manipulation::steeringMethod::EndEffectorTrajectory> > EndEffectorTrajectory;
+    } // end of namespace core.
+  } // end of namespace corbaServer.
+} // end of namespace hpp.
+
+#endif // HPP_MANIPULATION_IDL_STEERING_METHODS_HH

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,15 +32,15 @@ OMNIIDL_INCLUDE_DIRECTORIES(
   )
 
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/src)
-FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/hpp/corbaserver/manipulation)
 
+FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/hpp/corbaserver/manipulation)
 FOREACH(IDL ${IDL_SOURCES})
   GENERATE_IDL_CPP (hpp/corbaserver/manipulation/${IDL}
     ${CMAKE_SOURCE_DIR}/idl/hpp/corbaserver/manipulation
     HEADER_SUFFIX -idl.hh)
   GENERATE_IDL_PYTHON (${IDL} ${CMAKE_SOURCE_DIR}/idl/hpp/corbaserver/manipulation
     ENABLE_DOCSTRING
-    STUBS hpp_stubs.manipulation
+    STUBS hpp_stubs.corbaserver.manipulation
     ARGUMENTS
     -Wbmodules=hpp_idl
     -Wbextern=common:hpp_stubs
@@ -48,13 +48,43 @@ FOREACH(IDL ${IDL_SOURCES})
   INSTALL(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/hpp/corbaserver/manipulation/${IDL}-idl.hh
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hpp/corbaserver/manipulation)
-  INSTALL(FILES ${CMAKE_SOURCE_DIR}/idl/hpp/corbaserver/manipulation/${IDL}.idl
-    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/idl/hpp/corbaserver/manipulation)
+ENDFOREACH()
+
+FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/hpp/manipulation_idl)
+FOREACH(IDL steering_methods)
+  GENERATE_IDL_CPP (hpp/manipulation_idl/${IDL}
+    ${CMAKE_SOURCE_DIR}/idl/hpp/manipulation_idl
+    ARGUMENTS
+    -Wbguard_prefix=hpp_manipulation_idl
+    HEADER_SUFFIX -idl.hh)
+  GENERATE_IDL_PYTHON (${IDL} ${CMAKE_SOURCE_DIR}/idl/hpp/manipulation_idl
+    ENABLE_DOCSTRING
+    STUBS hpp_stubs.manipulation
+    ARGUMENTS
+    -Wbmodules=hpp_idl
+    -Wbextern=common:hpp_stubs
+    -Wbextern=gcommon:hpp_stubs.corbaserver.manipulation
+    -Wbextern=paths:hpp_stubs.core
+    -Wbextern=steering_methods:hpp_stubs.core
+    -Wbextern=constraints:hpp_stubs.constraints
+    )
+  INSTALL(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/hpp/manipulation_idl/${IDL}-idl.hh
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hpp/manipulation_idl)
 ENDFOREACH()
 
 INSTALL(
+  DIRECTORY ${CMAKE_SOURCE_DIR}/idl/hpp
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/idl/)
+INSTALL(
   DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/hpp_idl/hpp/corbaserver/manipulation
   DESTINATION ${PYTHON_SITELIB}/hpp_idl/hpp/corbaserver)
+INSTALL(
+  DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/hpp_idl/hpp/manipulation_idl
+  DESTINATION ${PYTHON_SITELIB}/hpp_idl/hpp/)
+INSTALL(
+  DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/hpp_stubs/corbaserver/manipulation
+  DESTINATION ${PYTHON_SITELIB}/hpp_stubs/corbaserver)
 INSTALL(
   DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/hpp_stubs/manipulation
   DESTINATION ${PYTHON_SITELIB}/hpp_stubs)
@@ -67,8 +97,6 @@ ADD_LIBRARY(${LIBRARY_NAME} SHARED
   client.cc
   )
 
-PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} hpp-manipulation)
-PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} hpp-manipulation-urdf)
 PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} omniORB4)
 
 INSTALL(TARGETS ${LIBRARY_NAME} DESTINATION lib)
@@ -86,8 +114,9 @@ IF (NOT CLIENT_ONLY)
     robot.impl.hh
     server.cc
     tools.cc # Should be moved into the library
+    manipulation_idl/steering-methods.cc
     LINK_DEPENDENCIES hpp-manipulation-corba
-    PKG_CONFIG_DEPENDENCIES omniORB4 hpp-corbaserver)
+    PKG_CONFIG_DEPENDENCIES omniORB4 hpp-corbaserver hpp-manipulation hpp-manipulation-urdf)
 
 
   # Stand alone corba server

--- a/src/hpp-manipulation-corba.cc
+++ b/src/hpp-manipulation-corba.cc
@@ -32,9 +32,9 @@ int main (int argc, char* argv [])
   std::cerr << " is provided for backward compatibility.\n"
     "You can now use hppcorbaserver and add the following lines to your Python script:\n"
     "from hpp.corbaserver import loadServerPlugin\n"
-    "loadServerPlugin (\"corbaserver\", \"manipulation-corba.so\")"
-    "# eventually "
-    "# loadServerPlugin (\"corbaserver\", \"wholebody-step-corba.so\")"
+    "loadServerPlugin (\"corbaserver\", \"manipulation-corba.so\")\n"
+    "# eventually\n"
+    "# loadServerPlugin (\"corbaserver\", \"wholebody-step-corba.so\")\n"
     << std::endl;
 
   ProblemSolverPtr_t problemSolver = new ProblemSolver();

--- a/src/hpp/corbaserver/manipulation/__init__.py
+++ b/src/hpp/corbaserver/manipulation/__init__.py
@@ -1,3 +1,5 @@
+import hpp_idl.hpp.manipulation_idl
+
 from .client import Client
 from .problem_solver import ProblemSolver, newProblem
 from .constraint_graph import ConstraintGraph

--- a/src/hpp/corbaserver/manipulation/__init__.py
+++ b/src/hpp/corbaserver/manipulation/__init__.py
@@ -6,3 +6,5 @@ from .constraint_graph import ConstraintGraph
 from .constraint_graph_factory import ConstraintGraphFactory
 from .constraints import Constraints
 from .robot import CorbaClient
+
+from hpp_idl.hpp.corbaserver.manipulation import Rule

--- a/src/manipulation_idl/steering-methods.cc
+++ b/src/manipulation_idl/steering-methods.cc
@@ -1,0 +1,22 @@
+// Copyright (C) 2019 by Joseph Mirabel, LAAS-CNRS.
+//
+// This file is part of the hpp-corbaserver.
+//
+// This software is provided "as is" without warranty of any kind,
+// either expressed or implied, including but not limited to the
+// implied warranties of fitness for a particular purpose.
+//
+// See the COPYING file for more information.
+
+#include "hpp/manipulation_idl/steering-methods.hh"
+
+namespace hpp
+{
+  namespace corbaServer
+  {
+    namespace manipulation_idl
+    {
+      HPP_CORBASERVER_ADD_DOWNCAST_OBJECT(EndEffectorTrajectory, core_idl::SteeringMethod, 1)
+    } // end of namespace manipulation.
+  } // end of namespace corbaServer.
+} // end of namespace hpp.


### PR DESCRIPTION
Note that most of the code of this PR will be removed when the omniidl backends from hpp-corbaserver will be plugged here. See https://github.com/humanoid-path-planner/hpp-corbaserver/pull/74