### PR TITLE
Homogeneize idl and python API

### DIFF
--- a/idl/hpp/corbaserver/manipulation/graph.idl
+++ b/idl/hpp/corbaserver/manipulation/graph.idl
@@ -196,6 +196,28 @@ module hpp {
         void getNode (in floatSeq dofArray, out ID nodeId)
           raises (Error);
 
+        /// Apply constaints of a state to a configuration
+        ///
+        /// \param idComp ID of a state (node of the constraint graph)
+        /// \param input input configuration,
+        /// \retval output output configuration,
+        /// \retval error norm of the residual error.
+        boolean applyNodeConstraints (in ID idComp, in floatSeq input, out floatSeq output,
+            out double residualError)
+          raises (Error);
+
+        /// Generate configuration in target state of a transition reachable from a configuration
+        ///
+        /// \param IDedge ID of a transition (edge of the constraint graph)
+        /// \param qleaf configuration defining the leaf of the transition
+        /// \param input input configuration to be projected
+        /// \retval output output configuration,
+        /// \retval error norm of the residual error.
+        boolean generateTargetConfig (in ID IDedge, in floatSeq qleaf,
+                                      in floatSeq input, out floatSeq output,
+                                      out double residualError)
+          raises (Error);
+
 	/// Get error of a config with respect to a node constraint
 	///
 	/// \param nodeId id of the node.

--- a/idl/hpp/corbaserver/manipulation/problem.idl
+++ b/idl/hpp/corbaserver/manipulation/problem.idl
@@ -163,6 +163,7 @@ module hpp {
         /// \param input input configuration,
         /// \retval output output configuration,
         /// \retval error norm of the residual error.
+        /// \deprecated Use Graph::applyNodeConstraints instead
         boolean applyConstraints (in ID idComp, in floatSeq input, out floatSeq output,
             out double residualError)
           raises (Error);
@@ -176,6 +177,7 @@ module hpp {
         /// \retval error norm of the residual error.
 	///
 	/// Call method using hpp::manipulation::graph::Edge::applyConstraints.
+        /// \deprecated Use Graph::generateTargetConfig instead.
         boolean applyConstraintsWithOffset (in ID IDedge, in floatSeq qnear, in floatSeq input, out floatSeq output,
             out double residualError)
           raises (Error);

--- a/src/graph.impl.hh
+++ b/src/graph.impl.hh
@@ -154,6 +154,16 @@ namespace hpp {
           virtual void getNode (const hpp::floatSeq& dofArray, ID_out output)
             throw (hpp::Error);
 
+        virtual bool applyNodeConstraints
+        (hpp::ID id, const hpp::floatSeq& input,
+         hpp::floatSeq_out output, double& residualError)
+          throw (hpp::Error);
+
+        virtual bool generateTargetConfig
+        (hpp::ID IDedge, const hpp::floatSeq& qleaf, const hpp::floatSeq& input,
+         hpp::floatSeq_out output, double& residualError)
+          throw (hpp::Error);
+
 	virtual CORBA::Boolean getConfigErrorForNode
 	(ID nodeId, const hpp::floatSeq& dofArray, hpp::floatSeq_out error)
 	  throw (hpp::Error);

--- a/src/hpp/corbaserver/manipulation/constraint_graph.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph.py
@@ -498,8 +498,8 @@ class ConstraintGraph (object):
     #  \retval output output configuration,
     #  \retval error norm of the residual error.
     def  applyNodeConstraints (self, node,  input) :
-        return self.client.problem.applyConstraints (self.nodes [node],
-                                                     input)
+        return self.client.graph.applyNodeConstraints (self.nodes [node],
+                                                       input)
 
     ## Apply edge constaints to a configuration
     #
@@ -513,7 +513,7 @@ class ConstraintGraph (object):
     #  Compute a configuration in the destination node of the edge,
     #  reachable from qFrom.
     def generateTargetConfig (self, edge, qfrom, input) :
-        return self.client.problem.applyConstraintsWithOffset \
+        return self.client.graph.generateTargetConfig \
             (self.edges [edge], qfrom, input)
 
     ## Build a path from qb to qe using the Edge::build.


### PR DESCRIPTION
  - move and rename Problem::applyConstraints -> Graph::applyNodeConstraints,
  - move and rename Problem::applyConstraintsWithOffset ->
    Graph::generateTargetConfig,
  - make idl method in Problem deprecated.