### PR TITLE
Modify the way urdf and srdf files are handled

### DIFF
--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -1,5 +1,6 @@
 INPUT		= @CMAKE_SOURCE_DIR@/include \
 		  @CMAKE_BINARY_DIR@/doc \
+		  @CMAKE_SOURCE_DIR@/doc \
 		  @CMAKE_SOURCE_DIR@/idl \
 		  @CMAKE_SOURCE_DIR@/src/hpp/corbaserver/manipulation/problem_solver.py \
 		  @CMAKE_SOURCE_DIR@/src/hpp/corbaserver/manipulation/constraint_graph.py \

--- a/doc/porting-from-4-to-5.hh
+++ b/doc/porting-from-4-to-5.hh
@@ -1,0 +1,33 @@
+/// \page hpp_manipulation_corba_porting_notes Porting notes
+///
+/// \section hpp_manipulation_corba_porting_4_to_5 Porting your code from version 4 to version 5
+/// \subsection hpp_manipulation_corba_porting_4_to_5_1 Modification in idl API
+///
+/// \subsubsection hpp_manipulation_corba_porting_4_to_5_1_1 Methods
+/// hpp::corbaserver::manipulation::Robot::insertRobotModel,
+/// hpp::corbaserver::manipulation::Robot::insertRobotModelOnFrame, and
+/// hpp::corbaserver::manipulation::Robot::insertHumanoidModel
+///
+/// Arguments
+/// \li in string packageName, in string modelName, in string urdfSuffix, in string srdfSuffix have been replaced by
+/// \li in string urdfname, in string srdfname.
+///
+/// These latter arguments contain the full filename to the urdf and srdf files.
+/// They may include "package://" pattern.
+///
+/// \subsection hpp_manipulation_corba_porting_4_to_5_2 Modification in python API
+/// \subsubsection hpp_manipulation_corba_porting_4_to_5_2_1 Methods
+///
+/// \li insertRobotModel,
+/// \li insertRobotModelOnFrame,
+/// \li insertHumanoidModel,
+/// \li loadHumanoidModel, and
+/// \li loadEnvironmentModel
+///
+/// of class manipulation.robot.Robot
+///
+/// Arguments
+/// \li packageName, modelName, urdfSuffix, srdfSuffix have been replaced by
+/// \li urdfName, srdfName.
+///
+

--- a/idl/hpp/corbaserver/manipulation/robot.idl
+++ b/idl/hpp/corbaserver/manipulation/robot.idl
@@ -32,23 +32,18 @@ module hpp
     ///        (see hpp::manipulation::ProblemSolver::addRobot)
     /// \param rootJointType type of root joint among "anchor", "freeflyer",
     /// "planar",
-    /// \param packageName Name of the ROS package containing the model,
-    /// \param modelName Name of the package containing the model
-    /// \param urdfSuffix suffix for urdf file,
-    ///
-    /// The ros url are built as follows:
-    /// "package://${packageName}/urdf/${modelName}${urdfSuffix}.urdf"
-    /// "package://${packageName}/srdf/${modelName}${srdfSuffix}.srdf"
+    /// \param urdfName name of the urdf file. It may contain
+    ///        "file://", or "package://" prefixes.
+    /// \param srdfName name of the srdf file. It may contain
+    ///        "file://", or "package://" prefixes.
     ///
     void insertRobotModel (in string robotName, in string rootJointType,
-        in string packageName, in string modelName, in string urdfSuffix,
-        in string srdfSuffix)
+        in string urdfname, in string srdfname)
       raises (Error);
 
     /// \copydoc hpp::corbaserver::manipulation::robot::Robot::insertRobotModelOnFrame
     void insertRobotModelOnFrame (in string robotName, in string frameName,
-        in string rootJointType, in string packageName, in string modelName,
-        in string urdfSuffix, in string srdfSuffix)
+        in string rootJointType, in string urdfname, in string srdfname)
       raises (Error);
 
     ///  Insert robot model as a child of the root joint of the Device
@@ -75,17 +70,13 @@ module hpp
     ///        (see hpp::manipulation::ProblemSolver::addRobot)
     /// \param rootJointType type of root joint among "anchor", "freeflyer",
     /// "planar",
-    /// \param packageName Name of the ROS package containing the model,
-    /// \param modelName Name of the package containing the model
-    /// \param urdfSuffix suffix for urdf file,
-    ///
-    /// The ros url are built as follows:
-    /// "package://${packageName}/urdf/${modelName}${urdfSuffix}.urdf"
-    /// "package://${packageName}/srdf/${modelName}${srdfSuffix}.srdf"
+    /// \param urdfName name of the urdf file. It may contain
+    ///        "file://", or "package://" prefixes.
+    /// \param srdfName name of the srdf file. It may contain
+    ///        "file://", or "package://" prefixes.
     ///
     void insertHumanoidModel (in string robotName, in string rootJointType,
-        in string packageName, in string modelName, in string urdfSuffix,
-        in string srdfSuffix)
+        in string urdfname, in string srdfname)
       raises (Error);
 
     ///  Insert humanoid robot model as a child of the root joint of the Device

--- a/idl/hpp/corbaserver/manipulation/robot.idl
+++ b/idl/hpp/corbaserver/manipulation/robot.idl
@@ -101,14 +101,13 @@ module hpp
         in string urdfString, in string srdfString)
       raises (Error);
 
-    /// \deprecated use insertRobotModel(in string, in string, in string, in string, in string, in string) instead
-    void insertObjectModel (in string objectName, in string rootJointType,
-        in string packageName, in string modelName, in string urdfSuffix,
-        in string srdfSuffix)
-      raises (Error);
-
-    void loadEnvironmentModel (in string packageName, in string envModelName,
-        in string urdfSuffix, in string srdfSuffix, in string prefix)
+    /// Load model of the environment
+    ///
+    /// urdfName name of the urdf file describing the environment
+    /// srdfName name of the srdf file describing the environment,
+    /// prefix string added in front of object names.
+    void loadEnvironmentModel (in string urdfName, in string srdfName,
+                               in string prefix)
       raises (Error);
 
     /// Get the position of root joint of a robot in world frame

--- a/src/graph.impl.cc
+++ b/src/graph.impl.cc
@@ -694,7 +694,6 @@ namespace hpp {
           DevicePtr_t robot = getRobotOrThrow (problemSolver());
 	  ConfigurationPtr_t config = floatSeqToConfigPtr (robot, input, true);
 	  ConfigurationPtr_t qRhs = floatSeqToConfigPtr (robot, qleaf, true);
-          value_type dist = 0;
           ConstraintSetPtr_t cs (edge->pathConstraint ());
           assert (cs);
 

--- a/src/hpp/corbaserver/manipulation/robot.py
+++ b/src/hpp/corbaserver/manipulation/robot.py
@@ -65,8 +65,9 @@ class Robot (Parent):
     def loadModel (self, robotName, rootJointType):
         if self.load:
             self.client.basic.robot.createRobot (self.name)
-        self.insertRobotModel (robotName, rootJointType, self.packageName,
-                               self.urdfName, self.urdfSuffix, self.srdfSuffix)
+        urdfFilename, srdfFilename = self.urdfSrdfFilenames ()
+        self.insertRobotModel (robotName, rootJointType, urdfFilename,
+                               srdfFilename)
 
     ## Load robot model and insert it in the device
     #
@@ -74,19 +75,13 @@ class Robot (Parent):
     #         map (see hpp::manipulation::ProblemSolver::addRobot)
     #  \param rootJointType type of root joint among "anchor", "freeflyer",
     #         "planar",
-    #  \param packageName Name of the ROS package containing the model,
-    #  \param modelName Name of the package containing the model
-    #  \param urdfSuffix suffix for urdf file,
+    #  \param urdfName name of the urdf file
+    #  \param srdfName name of the srdf file
     #
-    #  The ros url are built as follows:
-    #  \li "package://${packageName}/urdf/${modelName}${urdfSuffix}.urdf"
-    #  \li "package://${packageName}/srdf/${modelName}${srdfSuffix}.srdf"
-    def insertRobotModel (self, robotName, rootJointType, packageName,
-            modelName, urdfSuffix, srdfSuffix):
+    def insertRobotModel (self, robotName, rootJointType, urdfName, srdfName):
         if self.load:
-            self.client.manipulation.robot.insertRobotModel (robotName,
-                    rootJointType, packageName, modelName, urdfSuffix,
-                    srdfSuffix)
+            self.client.manipulation.robot.insertRobotModel \
+                (robotName, rootJointType, urdfName, srdfName)
         self.robotNames.append (robotName)
         self.rootJointType[robotName] = rootJointType
         self.rebuildRanks ()
@@ -98,20 +93,14 @@ class Robot (Parent):
     # \param frameName name of the existing frame that will the root of the added robot,
     # \param rootJointType type of root joint among "anchor", "freeflyer",
     # "planar",
-    # \param packageName Name of the ROS package containing the model,
-    # \param modelName Name of the package containing the model
-    # \param urdfSuffix suffix for urdf file,
-    #
-    # The ros url are built as follows:
-    # "package://${packageName}/urdf/${modelName}${urdfSuffix}.urdf"
-    # "package://${packageName}/srdf/${modelName}${srdfSuffix}.srdf"
+    #  \param urdfName name of the urdf file
+    #  \param srdfName name of the srdf file
     #
     def insertRobotModelOnFrame (self, robotName, frameName, rootJointType,
-            packageName, modelName, urdfSuffix, srdfSuffix):
+                                 urdfName, srdfName):
         if self.load:
-            self.client.manipulation.robot.insertRobotModelOnFrame (robotName,
-                    frameName, rootJointType, packageName, modelName,
-                    urdfSuffix, srdfSuffix)
+            self.client.manipulation.robot.insertRobotModelOnFrame \
+                (robotName, frameName, rootJointType, urdfName, srdfName)
         self.robotNames.append (robotName)
         self.rootJointType[robotName] = rootJointType
         self.rebuildRanks ()
@@ -146,31 +135,26 @@ class Robot (Parent):
 
     ## Load humanoid robot model and insert it in the device
     #
-    #  \param robotName key of the robot in ProblemSolver object map
-    #         (see hpp::manipulation::ProblemSolver::addRobot)
+    #  \param robotName key of the robot in hpp::manipulation::ProblemSolver object
+    #         map (see hpp::manipulation::ProblemSolver::addRobot)
     #  \param rootJointType type of root joint among "anchor", "freeflyer",
     #         "planar",
-    #  \param packageName Name of the ROS package containing the model,
-    #  \param modelName Name of the package containing the model
-    #  \param urdfSuffix suffix for urdf file,
+    #  \param urdfName name of the urdf file
+    #  \param srdfName name of the srdf file
     #
-    #  The ros url are built as follows:
-    #  \li "package://${packageName}/urdf/${modelName}${urdfSuffix}.urdf"
-    #  \li "package://${packageName}/srdf/${modelName}${srdfSuffix}.srdf"
-    def insertHumanoidModel (self, robotName, rootJointType, packageName,
-                           modelName, urdfSuffix, srdfSuffix):
+    def insertHumanoidModel (self, robotName, rootJointType, urdfName,
+                             srdfName) :
         if self.load:
             self.client.manipulation.robot.insertHumanoidModel \
-                (robotName, rootJointType, packageName, modelName,
-                 urdfSuffix, srdfSuffix)
+                (robotName, rootJointType, urdfName, srdfName)
         self.robotNames.append (robotName)
         self.rootJointType[robotName] = rootJointType
         self.rebuildRanks ()
 
-    def loadHumanoidModel (self, robotName, rootJointType, packageName,
-                           modelName, urdfSuffix, srdfSuffix):
-        self.insertHumanoidModel (robotName, rootJointType, packageName,
-                           modelName, urdfSuffix, srdfSuffix)
+    def loadHumanoidModel (self, robotName, rootJointType, urdfName,
+                           srdfName):
+        self.insertHumanoidModel (robotName, rootJointType, urdfName,
+                                  srdfName)
 
     ## Load environment model and store in local map.
     #  Contact surfaces are build from the corresping srdf file.
@@ -179,19 +163,13 @@ class Robot (Parent):
     #
     #  \param envName key of the object in ProblemSolver object map
     #         (see hpp::manipulation::ProblemSolver::addRobot)
-    #  \param packageName Name of the ROS package containing the model,
-    #  \param modelName Name of the package containing the model
-    #  \param urdfSuffix suffix for urdf file,
-    #  \param srdfSuffix suffix for srdf file.
+    #  \param urdfName name of the urdf file,
+    #  \param srdfName name of the srdf file.
     #
-    #  The ros url are built as follows:
-    #  \li "package://${packageName}/urdf/${modelName}${urdfSuffix}.urdf"
-    #  \li "package://${packageName}/srdf/${modelName}${srdfSuffix}.srdf"
-    def loadEnvironmentModel (self, packageName, modelName,
-                         urdfSuffix, srdfSuffix, envName):
+    def loadEnvironmentModel (self, urdfName, srdfName, envName):
         if self.load:
-            self.client.manipulation.robot.loadEnvironmentModel (packageName,
-                    modelName, urdfSuffix, srdfSuffix, envName)
+            self.client.manipulation.robot.loadEnvironmentModel \
+                (urdfName, srdfName, envName)
         self.rootJointType[envName] = "Anchor"
 
     ## \name Joints
@@ -232,7 +210,8 @@ class HumanoidRobot (Robot, StaticStabilityConstraintsFactory):
         Robot.__init__ (self, compositeName, robotName, rootJointType, load, client)
 
     def loadModel (self, robotName, rootJointType):
-        self.client.basic.robot.createRobot (self.name)
+        if self.load:
+            self.client.basic.robot.createRobot (self.name)
+        urdfFilename, srdfFilename = self.urdfSrdfFilenames ()
         self.insertHumanoidModel \
-            (robotName, rootJointType, self.packageName, self.urdfName,
-             self.urdfSuffix, self.srdfSuffix)
+            (robotName, rootJointType, urdfFilename, srdfFilename)

--- a/src/robot.impl.cc
+++ b/src/robot.impl.cc
@@ -116,19 +116,17 @@ namespace hpp {
       }
 
       void Robot::insertRobotModel (const char* robotName,
-          const char* rootJointType, const char* packageName,
-          const char* modelName, const char* urdfSuffix,
-          const char* srdfSuffix)
+          const char* rootJointType, const char* urdfName,
+          const char* srdfName)
 	throw (Error)
       {
         insertRobotModelOnFrame (robotName, "universe", rootJointType,
-            packageName, modelName, urdfSuffix, srdfSuffix);
+                                 urdfName, srdfName);
       }
 
       void Robot::insertRobotModelOnFrame (const char* robotName,
           const char* frameName, const char* rootJointType,
-          const char* packageName, const char* modelName,
-          const char* urdfSuffix, const char* srdfSuffix)
+          const char* urdfName, const char* srdfName)
         throw (hpp::Error)
       {
 	try {
@@ -138,10 +136,9 @@ namespace hpp {
           if (!robot->model().existFrame (frameName))
             HPP_THROW(std::invalid_argument, "No frame named " << frameName << ".");
           pinocchio::FrameIndex frame = robot->model().getFrameId(frameName);
-          pinocchio::urdf::loadRobotModel (robot, frame, robotName, rootJointType,
-              packageName, modelName, urdfSuffix, srdfSuffix);
-	  srdf::loadModelFromFile (robot, robotName,
-              packageName, modelName, srdfSuffix);
+          pinocchio::urdf::loadModel (robot, frame, robotName, rootJointType,
+                                      urdfName, srdfName);
+	  srdf::loadModelFromFile (robot, robotName, srdfName);
           problemSolver()->resetProblem ();
 	} catch (const std::exception& exc) {
 	  throw Error (exc.what ());
@@ -185,20 +182,18 @@ namespace hpp {
       }
 
       void Robot::insertHumanoidModel (const char* robotName,
-          const char* rootJointType, const char* packageName,
-          const char* modelName, const char* urdfSuffix,
-          const char* srdfSuffix)
+          const char* rootJointType, const char* urdfName,
+          const char* srdfName)
 	throw (Error)
       {
 	try {
           DevicePtr_t robot = getOrCreateRobot (problemSolver());
           if (robot->robotFrames(robotName).size() > 0)
             HPP_THROW(std::invalid_argument, "A robot named " << robotName << " already exists");
-          pinocchio::urdf::loadRobotModel (robot, 0, robotName, rootJointType,
-              packageName, modelName, urdfSuffix, srdfSuffix);
+          pinocchio::urdf::loadModel (robot, 0, robotName, rootJointType,
+              urdfName, srdfName);
           pinocchio::urdf::setupHumanoidRobot (robot, robotName);
-          srdf::loadModelFromFile (robot, robotName,
-              packageName, modelName, srdfSuffix);
+          srdf::loadModelFromFile (robot, robotName, srdfName);
           problemSolver()->resetProblem ();
 	} catch (const std::exception& exc) {
 	  throw Error (exc.what ());
@@ -225,21 +220,17 @@ namespace hpp {
 	}
       }
 
-      void Robot::loadEnvironmentModel (const char* package,
-          const char* envModelName, const char* urdfSuffix,
-          const char* srdfSuffix, const char* prefix)
+      void Robot::loadEnvironmentModel (const char* urdfName,
+          const char* srdfName, const char* prefix)
 	throw (hpp::Error)
       {
 	try {
           DevicePtr_t robot = getRobotOrThrow (problemSolver());
 
-          std::string modelName (envModelName); 
           std::string p (prefix);
           DevicePtr_t object = Device::create (p);
-          pinocchio::urdf::loadUrdfModel (object, "anchor",
-              package, modelName + std::string(urdfSuffix));
-          srdf::loadModelFromFile (object, "",
-              package, envModelName, srdfSuffix);
+          pinocchio::urdf::loadModel (object, 0, "", "anchor", urdfName, "");
+          srdf::loadModelFromFile (object, "", srdfName);
           object->controlComputation(hpp::pinocchio::JOINT_POSITION);
           object->computeForwardKinematics();
           object->updateGeometryPlacements();

--- a/src/robot.impl.cc
+++ b/src/robot.impl.cc
@@ -184,15 +184,6 @@ namespace hpp {
 	}
       }
 
-      void Robot::insertObjectModel (const char* objectName,
-          const char* rootJointType, const char* packageName,
-          const char* modelName, const char* urdfSuffix,
-          const char* srdfSuffix)
-	throw (Error)
-      {
-        insertRobotModel (objectName, rootJointType, packageName, modelName, urdfSuffix, srdfSuffix);
-      }
-
       void Robot::insertHumanoidModel (const char* robotName,
           const char* rootJointType, const char* packageName,
           const char* modelName, const char* urdfSuffix,

--- a/src/robot.impl.hh
+++ b/src/robot.impl.hh
@@ -38,15 +38,13 @@ namespace hpp {
           }
 
           virtual void insertRobotModel (const char* robotName,
-              const char* rootJointType, const char* packageName,
-              const char* modelName, const char* urdfSuffix,
-              const char* srdfSuffix)
+              const char* rootJointType, const char* urdfName,
+              const char* srdfName)
             throw (hpp::Error);
 
           virtual void insertRobotModelOnFrame (const char* robotName,
               const char* frameName, const char* rootJointType,
-              const char* packageName, const char* modelName,
-              const char* urdfSuffix, const char* srdfSuffix)
+              const char* urdfName, const char* srdfName)
             throw (hpp::Error);
 
           virtual void insertRobotModelFromString (const char* robotName,
@@ -61,9 +59,8 @@ namespace hpp {
             throw (hpp::Error);
 
           virtual void insertHumanoidModel (const char* robotName,
-              const char* rootJointType, const char* packageName,
-              const char* modelName, const char* urdfSuffix,
-              const char* srdfSuffix)
+              const char* rootJointType, const char* urdfName,
+              const char* srdfName)
             throw (hpp::Error);
 
           virtual void insertHumanoidModelFromString (const char* robotName,
@@ -72,9 +69,8 @@ namespace hpp {
               const char* srdfString)
             throw (hpp::Error);
 
-          virtual void loadEnvironmentModel (const char* package,
-              const char* envModelName, const char* urdfSuffix,
-              const char* srdfSuffix, const char* prefix)
+          virtual void loadEnvironmentModel (const char* urdfName,
+              const char* srdfName, const char* prefix)
             throw (hpp::Error);
 
           virtual void loadEnvironmentModelFromString (const char* urdfString,

--- a/src/robot.impl.hh
+++ b/src/robot.impl.hh
@@ -60,12 +60,6 @@ namespace hpp {
               const char* srdfSuffix)
             throw (hpp::Error);
 
-          virtual void insertObjectModel (const char* objectName,
-              const char* rootJointType, const char* packageName,
-              const char* modelName, const char* urdfSuffix,
-              const char* srdfSuffix)
-            throw (hpp::Error);
-
           virtual void insertHumanoidModel (const char* robotName,
               const char* rootJointType, const char* packageName,
               const char* modelName, const char* urdfSuffix,


### PR DESCRIPTION

    formerly, urdf and srdf files needed to be in neighbor directories:
        package://pkg/[urdf|srdf]/.../robot[urdfSuffix|srdfSuffix].[urdf|srdf].
    Now one filename is given for the urdf file and one filename for the srdf
    file.
    Porting notes are provided in the html documentation.
Requires https://github.com/humanoid-path-planner/hpp-corbaserver/pull/104 and https://github.com/humanoid-path-planner/hpp-manipulation-urdf/pull/16.