### PR TITLE
[ProblemSolver] Wrap in python idl method related to contact surfaces.

### DIFF
--- a/idl/hpp/corbaserver/manipulation/problem.idl
+++ b/idl/hpp/corbaserver/manipulation/problem.idl
@@ -95,16 +95,42 @@ module hpp {
 	void createPreGrasp (in string name, in string gripper,
 			     in string handle) raises (Error);
 
+        /// Get names of environment contact surfaces
+        /// \sa class hpp::core::Shape_t
+        /// \note they are also accessible with getAvailable("EnvContact").
         Names_t getEnvironmentContactNames ()
           raises (Error);
 
+        /// Get names of environment contact surfaces on robot
+        /// \sa class hpp::core::Shape_t
+        /// \note those are also accessible with getAvailable("RobotContact").
         Names_t getRobotContactNames ()
           raises (Error);
 
-        Names_t getEnvironmentContact (in string name, out intSeq indexes,
+        /// Get environment contact from name
+        ///
+        /// A contact surface may be composed of several convex polygons.
+        /// Let us denote by n the number of polygons.
+        /// \param name name of the contact surface
+        /// \return a list of n times the same joint name
+        /// \retval indices sequence of n numbers of vertices one for each
+        ///         polygon,
+        /// \retval points sequence of vertices. The number should be the
+        ///         sum of the elements of indices.
+        Names_t getEnvironmentContact (in string name, out intSeq indices,
                                        out floatSeqSeq points)
           raises (Error);
 
+        /// Get robot contact from name
+        ///
+        /// A contact surface may be composed of several convex polygons.
+        /// Let us denote by n the number of polygons.
+        /// \param name name of the contact surface
+        /// \return a list of n times the same joint name
+        /// \retval indices sequence of n numbers of vertices one for each
+        ///         polygon,
+        /// \retval points sequence of vertices. The number should be the
+        ///         sum of the elements of indices.
         Names_t getRobotContact (in string name, out intSeq indexes,
                                  out floatSeqSeq points)
           raises (Error);

--- a/src/hpp/corbaserver/manipulation/problem_solver.py
+++ b/src/hpp/corbaserver/manipulation/problem_solver.py
@@ -69,6 +69,30 @@ class ProblemSolver (Parent):
         except:
             return self.client.manipulation.problem.getSelected (type)
 
+    ## \name Contact surfaces
+    #
+    #  In placement states, objects are in contact with other objects or with
+    #  the environment through contact surfaces.
+    #  \{
+
+    ##  \copydoc hpp::corbaserver::manipulation::Problem::getEnvironmentContactNames
+    def getEnvironmentContactNames(self):
+        return self.client.manipulation.problem.getEnvironmentContactNames()
+
+    ##  \copydoc hpp::corbaserver::manipulation::Problem::getRobotContactNames
+    def getRobotContactNames(self):
+        return self.client.manipulation.problem.getRobotContactNames()
+
+    ##  \copydoc hpp::corbaserver::manipulation::Problem::getEnvironmentContact
+    def getEnvironmentContact(self, name):
+        return self.client.manipulation.problem.getEnvironmentContact(name)
+
+    ##  \copydoc hpp::corbaserver::manipulation::Problem::getRobotContact
+    def getRobotContact(self, name):
+        return self.client.manipulation.problem.getRobotContact(name)
+
+    ## \}
+
     ## \name Constraints
     #  \{
 


### PR DESCRIPTION
  - Wrap in python the following idl methods
    - Problem::getEnvironmentContact,
    - Problem::getEnvironmentContactNames,
    - Problem::getRobotContact,
    - Problem::getRobotContactNames.

  - Document those methods and the corresponding idl interfaces.
