### PR TITLE
[Graph] add a method to set a security margin for a pair of joints

### DIFF
--- a/idl/hpp/corbaserver/manipulation/graph.idl
+++ b/idl/hpp/corbaserver/manipulation/graph.idl
@@ -405,6 +405,17 @@ module hpp {
         /// \retval matrix as defined in hpp::core::RelativeMotion::matrix_type.
         void getRelativeMotionMatrix (in ID edgeID, out intSeqSeq matrix)
           raises (Error);
+
+        /// Set collision security margin for a pair of joint along an edge
+        ///
+        /// \param edgeID index of the edge,
+        /// \param joint1, joint2 indices of joint1 and joint2 in robot
+        ///        (+1 since 0 stands for the environment),
+        /// \param margin security margin for collision tests between those
+        /// joints along the edge.
+        void setSecurityMarginForEdge(in ID edgeID, in long joint1,
+                                      in long joint2, in double margin)
+          raises(Error);
       }; // interface Graph
     }; // module manipulation
   }; // module corbaserver

--- a/idl/hpp/corbaserver/manipulation/graph.idl
+++ b/idl/hpp/corbaserver/manipulation/graph.idl
@@ -409,12 +409,11 @@ module hpp {
         /// Set collision security margin for a pair of joint along an edge
         ///
         /// \param edgeID index of the edge,
-        /// \param joint1, joint2 indices of joint1 and joint2 in robot
-        ///        (+1 since 0 stands for the environment),
+        /// \param joint1, joint2 names of joint1 and joint2
         /// \param margin security margin for collision tests between those
         /// joints along the edge.
-        void setSecurityMarginForEdge(in ID edgeID, in long joint1,
-                                      in long joint2, in double margin)
+        void setSecurityMarginForEdge(in ID edgeID, in string joint1,
+                                      in string joint2, in double margin)
           raises(Error);
       }; // interface Graph
     }; // module manipulation

--- a/src/graph.impl.cc
+++ b/src/graph.impl.cc
@@ -1047,11 +1047,13 @@ namespace hpp {
       }
 
       void Graph::setSecurityMarginForEdge
-      (ID edgeId, Long joint1, Long joint2, double margin)
+      (ID edgeId, const char* joint1, const char* joint2, double margin)
       {
         graph::EdgePtr_t edge = getComp <graph::Edge> (edgeId, true);
-        edge->securityMarginForPair(joint1, joint2, margin);
-        edge->securityMarginForPair(joint2, joint1, margin);
+        DevicePtr_t robot(edge->parentGraph()->robot());
+        JointPtr_t j1 (robot->getJointByName(joint1));
+        JointPtr_t j2 (robot->getJointByName(joint2));
+        edge->securityMarginForPair(j1->index(), j2->index(), margin);
       }
     } // namespace impl
   } // namespace manipulation

--- a/src/graph.impl.cc
+++ b/src/graph.impl.cc
@@ -1045,6 +1045,14 @@ namespace hpp {
         graph::EdgePtr_t edge = getComp <graph::Edge> (edgeId, true);
         matrix = matrixToIntSeqSeq(edge->relativeMotion().cast<CORBA::Long>());
       }
+
+      void Graph::setSecurityMarginForEdge
+      (ID edgeId, Long joint1, Long joint2, double margin)
+      {
+        graph::EdgePtr_t edge = getComp <graph::Edge> (edgeId, true);
+        edge->securityMarginForPair(joint1, joint2, margin);
+        edge->securityMarginForPair(joint2, joint1, margin);
+      }
     } // namespace impl
   } // namespace manipulation
 } // namespace hpp

--- a/src/graph.impl.hh
+++ b/src/graph.impl.hh
@@ -190,7 +190,7 @@ namespace hpp {
 
           virtual void getRelativeMotionMatrix (ID edgeID, intSeqSeq_out matrix);
           virtual void setSecurityMarginForEdge
-          (ID edgeId, Long joint1, Long joint2, double margin);
+          (ID edgeId, const char* joint1, const char* joint2, double margin);
         private:
           template <typename T> boost::shared_ptr<T> getComp(ID id, bool throwIfWrongType = true);
           ProblemSolverPtr_t problemSolver();

--- a/src/graph.impl.hh
+++ b/src/graph.impl.hh
@@ -189,7 +189,8 @@ namespace hpp {
           virtual void initialize ();
 
           virtual void getRelativeMotionMatrix (ID edgeID, intSeqSeq_out matrix);
-
+          virtual void setSecurityMarginForEdge
+          (ID edgeId, Long joint1, Long joint2, double margin);
         private:
           template <typename T> boost::shared_ptr<T> getComp(ID id, bool throwIfWrongType = true);
           ProblemSolverPtr_t problemSolver();

--- a/src/hpp/corbaserver/manipulation/constraint_graph.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph.py
@@ -55,6 +55,7 @@ class ConstraintGraph (object):
             }
 
     def __init__ (self, robot, graphName, makeGraph = True):
+        self.robot = robot
         self.client = robot.client.manipulation
         self.clientBasic = robot.client.basic
         self.graph = robot.client.manipulation.graph
@@ -658,9 +659,25 @@ class ConstraintGraph (object):
 
     def initialize (self):
         self.graph.initialize()
-
     ##
     # \}
+
+    ## Set collision security margin for a pair of joints along an edge
+    #
+    #  \param edge name of the edge,
+    #  \param joint1, joint2 names of the joints or "environment",
+    #  \param margin security margin.
+    def setSecurityMarginForEdge(self, edge, joint1, joint2, margin):
+        names = self.robot.getJointNames()
+        if joint1 == "environment":
+            j1 = 0
+        else:
+            j1 = names.index(joint1) + 1 #first joint is universe
+        if joint2 == "environment":
+            j2 = 0
+        else:
+            j2 = names.index(joint2) + 1 #first joint is universe
+        self.graph.setSecurityMarginForEdge(self.edges[edge], j1, j2, margin)
 
     ## get the textToTex translation
     def _ (self, text):

--- a/src/hpp/corbaserver/manipulation/constraint_graph.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph.py
@@ -665,19 +665,13 @@ class ConstraintGraph (object):
     ## Set collision security margin for a pair of joints along an edge
     #
     #  \param edge name of the edge,
-    #  \param joint1, joint2 names of the joints or "environment",
+    #  \param joint1, joint2 names of the joints or "universe" for the
+    #         environment,
     #  \param margin security margin.
     def setSecurityMarginForEdge(self, edge, joint1, joint2, margin):
         names = self.robot.getJointNames()
-        if joint1 == "environment":
-            j1 = 0
-        else:
-            j1 = names.index(joint1) + 1 #first joint is universe
-        if joint2 == "environment":
-            j2 = 0
-        else:
-            j2 = names.index(joint2) + 1 #first joint is universe
-        self.graph.setSecurityMarginForEdge(self.edges[edge], j1, j2, margin)
+        self.graph.setSecurityMarginForEdge(self.edges[edge], joint1, joint2,
+                                            margin)
 
     ## get the textToTex translation
     def _ (self, text):


### PR DESCRIPTION
  along an edge.
  - graph.idl, constraint_graph.py: setSecurityMarginForEdge.