### PR TITLE
[ConstraintGraphFactory] Add abstract method transitionIsAllowed

### DIFF
--- a/src/hpp/corbaserver/manipulation/constraint_graph_factory.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph_factory.py
@@ -291,10 +291,10 @@ class GraphFactoryAbstract(ABC):
                 nGrasps = grasps[:isg] + (ish, ) + grasps[isg+1:]
 
                 nextIsAllowed = self.graspIsAllowed (nGrasps)
-                if nextIsAllowed: next = self._makeState (nGrasps, depth + 1)
+                if nextIsAllowed: nnext = self._makeState (nGrasps, depth + 1)
 
                 if isAllowed and nextIsAllowed:
-                    self.makeTransition (current, next, isg)
+                    self.makeTransition (current, nnext, isg)
 
                 self._recurse (ngrippers, nhandles, nGrasps, depth + 2)
 

--- a/src/hpp/corbaserver/manipulation/constraint_graph_factory.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph_factory.py
@@ -497,6 +497,7 @@ class ConstraintGraphFactory(GraphFactoryAbstract):
 
     ## defaut distance between objec and surface in preplacement configuration
     defaultPreplaceDist = 0.05
+    ## See methods setPreplacementDistance and getPreplacementDistance
     preplaceDistance = dict()
 
     ## \param graph an instance of ConstraintGraph

--- a/src/hpp/corbaserver/manipulation/constraint_graph_factory.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph_factory.py
@@ -206,6 +206,11 @@ class GraphFactoryAbstract(ABC):
     @abc.abstractmethod
     def makeLoopTransition(self, state): pass
 
+    ## Check whether a transition between two states is allowed
+    #  \param stateFrom, stateTo states to connect
+    @abc.abstractmethod
+    def transitionIsAllowed(self, stateFrom, stateTo): return True
+
     ## Create two transitions between two different states.
     # \param stateFrom: same as grasps in \ref makeState
     # \param stateTo: same as grasps in \ref makeState
@@ -293,7 +298,8 @@ class GraphFactoryAbstract(ABC):
                 nextIsAllowed = self.graspIsAllowed (nGrasps)
                 if nextIsAllowed: nnext = self._makeState (nGrasps, depth + 1)
 
-                if isAllowed and nextIsAllowed:
+                if isAllowed and nextIsAllowed and self.transitionIsAllowed\
+                   (stateFrom = current, stateTo = nnext):
                     self.makeTransition (current, nnext, isg)
 
                 self._recurse (ngrippers, nhandles, nGrasps, depth + 2)


### PR DESCRIPTION
this abstract method tests whether 2 allowed states can be connected by a transition.
Default implementation returns True.
This PR adresses https://github.com/humanoid-path-planner/hpp-manipulation-corba/issues/98.