### PR TITLE
[Problem] Fix security margins for environment contact surfaces.

### DIFF
--- a/src/graph.impl.cc
+++ b/src/graph.impl.cc
@@ -1064,7 +1064,9 @@ namespace hpp {
         DevicePtr_t robot(edge->parentGraph()->robot());
         JointPtr_t j1 (robot->getJointByName(joint1));
         JointPtr_t j2 (robot->getJointByName(joint2));
-        edge->securityMarginForPair(j1->index(), j2->index(), margin);
+	size_type i1 = 0; if (j1) { i1 = j1->index();}
+	size_type i2 = 0; if (j2) { i2 = j2->index();}
+        edge->securityMarginForPair(i1, i2, margin);
 	} catch (const std::exception& exc) {
 	  throw Error (exc.what ());
 	}

--- a/src/graph.impl.cc
+++ b/src/graph.impl.cc
@@ -1064,8 +1064,8 @@ namespace hpp {
         DevicePtr_t robot(edge->parentGraph()->robot());
         JointPtr_t j1 (robot->getJointByName(joint1));
         JointPtr_t j2 (robot->getJointByName(joint2));
-	size_type i1 = 0; if (j1) { i1 = j1->index();}
-	size_type i2 = 0; if (j2) { i2 = j2->index();}
+        size_type i1 = 0; if (j1) { i1 = j1->index();}
+        size_type i2 = 0; if (j2) { i2 = j2->index();}
         edge->securityMarginForPair(i1, i2, margin);
 	} catch (const std::exception& exc) {
 	  throw Error (exc.what ());

--- a/src/hpp/corbaserver/manipulation/security_margins.py
+++ b/src/hpp/corbaserver/manipulation/security_margins.py
@@ -65,7 +65,7 @@ class SecurityMargins(object):
             l = len(ro)
             self.robotToJoints[ro] = list(filter(lambda n:n[:l+1] == ro + "/",
                                             self.robot.jointNames))
-        self.robotToJoints["universe"] = ['NONE']
+        self.robotToJoints["universe"] = ['universe']
         self.jointToRobot = dict()
         for ro, joints in self.robotToJoints.items():
             for j in joints:

--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -76,7 +76,7 @@ namespace hpp {
               strcpy (nameList[rank], itJs->first->name().c_str ());
             } else {
               nameList[rank] = new char[5];
-              strcpy (nameList[rank], "NONE");
+              strcpy (nameList[rank], "universe");
             }
             nbPts += itJs->second.size ();
             (*indexes)[rank] = (int) nbPts;


### PR DESCRIPTION
  When joint is "universe", joint->index() fails since joint is 0x0.