### PR TITLE
[SecurityMargins] Allow other separtors besides '/'

### DIFF
--- a/src/hpp/corbaserver/manipulation/security_margins.py
+++ b/src/hpp/corbaserver/manipulation/security_margins.py
@@ -65,6 +65,7 @@ class SecurityMargins:
     """
     Separators to guess wich joint belongs to which robot
     """
+
     def __init__(self, problemSolver, factory, robotsAndObjects):
         """
         Constructor
@@ -85,8 +86,10 @@ class SecurityMargins:
         for ro in self.robotsAndObjects:
             le = len(ro)
             self.robotToJoints[ro] = list(
-                filter(lambda n: n[: le] == ro and n[le] in self.separators,
-                       self.robot.jointNames)
+                filter(
+                    lambda n: n[:le] == ro and n[le] in self.separators,
+                    self.robot.jointNames,
+                )
             )
         self.robotToJoints["universe"] = ["universe"]
         self.jointToRobot = dict()

--- a/src/hpp/corbaserver/manipulation/security_margins.py
+++ b/src/hpp/corbaserver/manipulation/security_margins.py
@@ -61,7 +61,10 @@ class SecurityMargins:
     """
 
     defaultMargin = 0
-
+    separators = ["/"]
+    """
+    Separators to guess wich joint belongs to which robot
+    """
     def __init__(self, problemSolver, factory, robotsAndObjects):
         """
         Constructor
@@ -82,7 +85,8 @@ class SecurityMargins:
         for ro in self.robotsAndObjects:
             le = len(ro)
             self.robotToJoints[ro] = list(
-                filter(lambda n: n[: le + 1] == ro + "/", self.robot.jointNames)
+                filter(lambda n: n[: le] == ro and n[le] in self.separators,
+                       self.robot.jointNames)
             )
         self.robotToJoints["universe"] = ["universe"]
         self.jointToRobot = dict()


### PR DESCRIPTION
  to separate robot and object names.
  When loading 2 franka robots, the joint names are of type
    - .../panda1_joint1, .../panda1_joint2, ...
    - .../panda1_joint1, .../panda2_joint2, ... To distinguish joints of first robot from joints from second robot, we need to pass ".../panda1" and ".../panda2" as robot names and use '_' as a separator.
The default behavior remains the same however.