### PR TITLE
Fix and improvement

### DIFF
--- a/idl/hpp/corbaserver/manipulation/robot.idl
+++ b/idl/hpp/corbaserver/manipulation/robot.idl
@@ -139,8 +139,9 @@ module hpp
     /// \param linkName name of the link (hpp::model::Body) holding the gripper,
     /// \param gripperName name of the gripper,
     /// \param handlePositioninJoint position of the handle in the joint frame.
+    /// \param clearance clearance of the gripper
     void addGripper (in string linkName, in string gripperName,
-        in Transform_ handlePositioninJoint)
+                     in Transform_ handlePositioninJoint, in double clearance)
       raises (Error);
 
     /// Add \link hpp::manipulation::Handle Handle \endlink to an object
@@ -148,9 +149,10 @@ module hpp
     /// \param linkName name of the link holding the handle,
     /// \param handleName name of the handle,
     /// \param localPosition position of the handle in the joint frame.
+    /// \param clearance clearance of the gripper
     /// \param mask mask of the handle.
     void addHandle (in string linkName, in string handleName,
-                    in Transform_ localPosition, in boolSeq mask)
+        in Transform_ localPosition, in double clearance, in boolSeq mask)
       raises (Error);
 
     /// Return the joint name in which a gripper is and the position relatively

--- a/idl/hpp/corbaserver/manipulation/robot.idl
+++ b/idl/hpp/corbaserver/manipulation/robot.idl
@@ -143,23 +143,14 @@ module hpp
         in Transform_ handlePositioninJoint)
       raises (Error);
 
-    /// Add Handle to an object
+    /// Add \link hpp::manipulation::Handle Handle \endlink to an object
     ///
-    /// \param linkName name of the link (hpp::model::Body) holding the handle,
+    /// \param linkName name of the link holding the handle,
     /// \param handleName name of the handle,
     /// \param localPosition position of the handle in the joint frame.
+    /// \param mask mask of the handle.
     void addHandle (in string linkName, in string handleName,
-        in Transform_ localPosition)
-      raises (Error);
-
-    /// Add axial handle to an object
-    ///
-    /// \param linkName name of the link (hpp::model::Body) holding the handle,
-    /// \param handleName name of the handle,
-    /// \param localPosition position of the handle in the joint frame,
-    ///        rotation around x-axis is not constrained.
-    void addAxialHandle (in string linkName, in string handleName,
-        in Transform_ localPosition)
+                    in Transform_ localPosition, in boolSeq mask)
       raises (Error);
 
     /// Return the joint name in which a gripper is and the position relatively

--- a/src/graph.impl.cc
+++ b/src/graph.impl.cc
@@ -514,8 +514,11 @@ void Graph::addNumericalConstraints(const Long graphComponentId,
     try {
       for (CORBA::ULong i = 0; i < constraintNames.length(); ++i) {
         std::string name(constraintNames[i]);
-        if (!problemSolver()->numericalConstraint(name))
-          throw Error("The numerical function does not exist.");
+        if (!problemSolver()->numericalConstraint(name)) {
+          std::ostringstream os;
+          os << "Numerical constraint \"" << name << "\" does not exist.";
+          throw Error(os.str().c_str());
+        }
         component->addNumericalConstraint(
             problemSolver()->numericalConstraint(name));
       }

--- a/src/hpp/corbaserver/manipulation/constraint_graph_factory.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph_factory.py
@@ -34,15 +34,6 @@ import sys
 from .constraints import Constraints
 
 
-def _removeEmptyConstraints(problem, constraints):
-    return [
-        n
-        for n in constraints
-        if n in problem.getAvailable("numericalconstraint")
-        and problem.getConstraintDimensions(n)[2] > 0
-    ]
-
-
 class Rules(object):
     def __init__(self, grippers, handles, rules):
         rs = []
@@ -523,6 +514,26 @@ class ConstraintFactory(ConstraintFactoryAbstract):
     Default implementation of ConstraintFactoryAbstract
     """
 
+    removeEmptyConstraints = True
+    """
+    This flag determines whether preplacement states are added when no
+    contact surface is present. Setting it to false may be useful in order
+    to keep the same graph topology and to populate the graph with dedicated
+    constraints.
+    """
+    def _removeEmptyConstraints(self, problem, constraints):
+        if self.removeEmptyConstraints:
+            return [
+                n
+                for n in constraints
+                if n in problem.getAvailable("numericalconstraint")
+                and problem.getConstraintDimensions(n)[2] > 0
+            ]
+        else:
+            return constraints
+
+
+
     gfields = ("grasp", "graspComplement", "preGrasp")
     pfields = ("placement", "placementComplement", "prePlacement")
 
@@ -555,7 +566,7 @@ class ConstraintFactory(ConstraintFactoryAbstract):
                     self.gfields,
                     (
                         Constraints(
-                            numConstraints=_removeEmptyConstraints(
+                            numConstraints=self._removeEmptyConstraints(
                                 self.graph.clientBasic.problem,
                                 [
                                     n,
@@ -563,7 +574,7 @@ class ConstraintFactory(ConstraintFactoryAbstract):
                             )
                         ),
                         Constraints(
-                            numConstraints=_removeEmptyConstraints(
+                            numConstraints=self._removeEmptyConstraints(
                                 self.graph.clientBasic.problem,
                                 [
                                     n + "/complement",
@@ -571,7 +582,7 @@ class ConstraintFactory(ConstraintFactoryAbstract):
                             )
                         ),
                         Constraints(
-                            numConstraints=_removeEmptyConstraints(
+                            numConstraints=self._removeEmptyConstraints(
                                 self.graph.clientBasic.problem,
                                 [
                                     pn,
@@ -639,7 +650,7 @@ class ConstraintFactory(ConstraintFactoryAbstract):
                     self.pfields,
                     (
                         Constraints(
-                            numConstraints=_removeEmptyConstraints(
+                            numConstraints=self._removeEmptyConstraints(
                                 self.graph.clientBasic.problem,
                                 [
                                     n,
@@ -647,7 +658,7 @@ class ConstraintFactory(ConstraintFactoryAbstract):
                             )
                         ),
                         Constraints(
-                            numConstraints=_removeEmptyConstraints(
+                            numConstraints=self._removeEmptyConstraints(
                                 self.graph.clientBasic.problem,
                                 [
                                     n + "/complement",
@@ -655,7 +666,7 @@ class ConstraintFactory(ConstraintFactoryAbstract):
                             )
                         ),
                         Constraints(
-                            numConstraints=_removeEmptyConstraints(
+                            numConstraints=self._removeEmptyConstraints(
                                 self.graph.clientBasic.problem,
                                 [
                                     pn,

--- a/src/hpp/corbaserver/manipulation/constraint_graph_factory.py
+++ b/src/hpp/corbaserver/manipulation/constraint_graph_factory.py
@@ -521,6 +521,7 @@ class ConstraintFactory(ConstraintFactoryAbstract):
     to keep the same graph topology and to populate the graph with dedicated
     constraints.
     """
+
     def _removeEmptyConstraints(self, problem, constraints):
         if self.removeEmptyConstraints:
             return [
@@ -531,8 +532,6 @@ class ConstraintFactory(ConstraintFactoryAbstract):
             ]
         else:
             return constraints
-
-
 
     gfields = ("grasp", "graspComplement", "preGrasp")
     pfields = ("placement", "placementComplement", "prePlacement")

--- a/src/robot.impl.cc
+++ b/src/robot.impl.cc
@@ -362,7 +362,8 @@ void Robot::setRootJointPosition(const char* robotName,
 }
 
 void Robot::addHandle(const char* linkName, const char* handleName,
-    const ::hpp::Transform_ localPosition, const ::hpp::boolSeq& mask) {
+    const ::hpp::Transform_ localPosition, double clearance,
+    const ::hpp::boolSeq& mask) {
   try {
     DevicePtr_t robot = getRobotOrThrow(problemSolver());
     JointPtr_t joint = getJointByBodyNameOrThrow(problemSolver(), linkName);
@@ -375,6 +376,7 @@ void Robot::addHandle(const char* linkName, const char* handleName,
     }
     hppTransformToTransform3f(localPosition, T);
     HandlePtr_t handle = Handle::create(handleName, T, robot, joint);
+    handle->clearance(clearance);
     handle->mask(corbaServer::boolSeqToVector(mask, 6));
     robot->handles.add(handleName, handle);
     assert(robot->model().existFrame(jointName));
@@ -387,7 +389,7 @@ void Robot::addHandle(const char* linkName, const char* handleName,
 }
 
 void Robot::addGripper(const char* linkName, const char* gripperName,
-                       const ::hpp::Transform_ p) {
+                       const ::hpp::Transform_ p, double clearance) {
   try {
     DevicePtr_t robot = getRobotOrThrow(problemSolver());
     JointPtr_t joint = getJointByBodyNameOrThrow(problemSolver(), linkName);
@@ -404,6 +406,7 @@ void Robot::addGripper(const char* linkName, const char* gripperName,
     robot->model().addFrame(::pinocchio::Frame(
         gripperName, index, previousFrame, T, ::pinocchio::OP_FRAME));
     GripperPtr_t gripper = Gripper::create(gripperName, robot);
+    gripper->clearance(clearance);
     robot->grippers.add(gripperName, gripper);
     // hppDout (info, "add Gripper: " << *gripper);
   } catch (const std::exception& exc) {

--- a/src/robot.impl.cc
+++ b/src/robot.impl.cc
@@ -362,8 +362,8 @@ void Robot::setRootJointPosition(const char* robotName,
 }
 
 void Robot::addHandle(const char* linkName, const char* handleName,
-    const ::hpp::Transform_ localPosition, double clearance,
-    const ::hpp::boolSeq& mask) {
+                      const ::hpp::Transform_ localPosition, double clearance,
+                      const ::hpp::boolSeq& mask) {
   try {
     DevicePtr_t robot = getRobotOrThrow(problemSolver());
     JointPtr_t joint = getJointByBodyNameOrThrow(problemSolver(), linkName);

--- a/src/robot.impl.hh
+++ b/src/robot.impl.hh
@@ -94,10 +94,11 @@ class Robot : public virtual POA_hpp::corbaserver::manipulation::Robot {
                                     const ::hpp::Transform_ position);
 
   virtual void addHandle(const char* linkName, const char* handleName,
-      const ::hpp::Transform_ localPosition, const ::hpp::boolSeq& mask);
+      const ::hpp::Transform_ localPosition, double clearance,
+      const ::hpp::boolSeq& mask);
 
   virtual void addGripper(const char* linkName, const char* gripperName,
-                          const ::hpp::Transform_ handlePositioninJoint);
+      const ::hpp::Transform_ handlePositioninJoint, double clearance);
 
   virtual char* getGripperPositionInJoint(const char* gripperName,
                                           ::hpp::Transform__out position);

--- a/src/robot.impl.hh
+++ b/src/robot.impl.hh
@@ -94,13 +94,10 @@ class Robot : public virtual POA_hpp::corbaserver::manipulation::Robot {
                                     const ::hpp::Transform_ position);
 
   virtual void addHandle(const char* linkName, const char* handleName,
-                         const ::hpp::Transform_ localPosition);
+      const ::hpp::Transform_ localPosition, const ::hpp::boolSeq& mask);
 
   virtual void addGripper(const char* linkName, const char* gripperName,
                           const ::hpp::Transform_ handlePositioninJoint);
-
-  virtual void addAxialHandle(const char* linkName, const char* handleName,
-                              const ::hpp::Transform_ localPosition);
 
   virtual char* getGripperPositionInJoint(const char* gripperName,
                                           ::hpp::Transform__out position);

--- a/src/robot.impl.hh
+++ b/src/robot.impl.hh
@@ -94,11 +94,12 @@ class Robot : public virtual POA_hpp::corbaserver::manipulation::Robot {
                                     const ::hpp::Transform_ position);
 
   virtual void addHandle(const char* linkName, const char* handleName,
-      const ::hpp::Transform_ localPosition, double clearance,
-      const ::hpp::boolSeq& mask);
+                         const ::hpp::Transform_ localPosition,
+                         double clearance, const ::hpp::boolSeq& mask);
 
   virtual void addGripper(const char* linkName, const char* gripperName,
-      const ::hpp::Transform_ handlePositioninJoint, double clearance);
+                          const ::hpp::Transform_ handlePositioninJoint,
+                          double clearance);
 
   virtual char* getGripperPositionInJoint(const char* gripperName,
                                           ::hpp::Transform__out position);


### PR DESCRIPTION
This PR
  - allow users to create preplacement states in the constraint graph eventhough the placement constraint of the corresponding object is of dimension 0 (the default behavior remains the same).
  -  fixes idl methods to create handles and grippers.