### PR TITLE
Modified piece wise

### DIFF
--- a/idl/hpp/manipulation_idl/_path_planners.idl
+++ b/idl/hpp/manipulation_idl/_path_planners.idl
@@ -70,27 +70,6 @@ module hpp
         void setIkSolverInitialization (in IkSolverInitialization solver);
         //-> ikSolverInitialization
       }; // interface EET_PIECEWISE
-
-      interface EET_HERMITE : core_idl::PathPlanner
-      {
-        long getNRandomConfig (         ) raises (Error);
-        //-> nRandomConfig
-        void setNRandomConfig (in long n) raises (Error);
-        //-> nRandomConfig
-
-        long getNDiscreteSteps (         ) raises (Error);
-        //-> nDiscreteSteps
-        void setNDiscreteSteps (in long n) raises (Error);
-        //-> nDiscreteSteps
-
-        boolean getCheckFeasibilityOnly (            ) raises (Error);
-        //-> checkFeasibilityOnly
-        void    setCheckFeasibilityOnly (in boolean n) raises (Error);
-        //-> checkFeasibilityOnly
-
-        void setIkSolverInitialization (in IkSolverInitialization solver);
-        //-> ikSolverInitialization
-      }; // interface EET_HERMITE
     }; // module pathPlanner_idl
   }; // module manipulation_idl
 }; // module hpp

--- a/idl/hpp/manipulation_idl/_path_planners.idl
+++ b/idl/hpp/manipulation_idl/_path_planners.idl
@@ -31,6 +31,8 @@
 
 #include <hpp/core_idl/path_planners.idl>
 #include <hpp/manipulation_idl/_graph.idl>
+#include <hpp/core_idl/paths.idl>
+
 
 module hpp
 {
@@ -48,7 +50,7 @@ module hpp
       {
       }; // interface IkSolverInitialization
 
-      interface EndEffectorTrajectory : core_idl::PathPlanner
+      interface EET_PIECEWISE : core_idl::PathPlanner
       {
         long getNRandomConfig (         ) raises (Error);
         //-> nRandomConfig
@@ -67,7 +69,28 @@ module hpp
 
         void setIkSolverInitialization (in IkSolverInitialization solver);
         //-> ikSolverInitialization
-      }; // interface EndEffectorTrajectory
+      }; // interface EET_PIECEWISE
+
+      interface EET_HERMITE : core_idl::PathPlanner
+      {
+        long getNRandomConfig (         ) raises (Error);
+        //-> nRandomConfig
+        void setNRandomConfig (in long n) raises (Error);
+        //-> nRandomConfig
+
+        long getNDiscreteSteps (         ) raises (Error);
+        //-> nDiscreteSteps
+        void setNDiscreteSteps (in long n) raises (Error);
+        //-> nDiscreteSteps
+
+        boolean getCheckFeasibilityOnly (            ) raises (Error);
+        //-> checkFeasibilityOnly
+        void    setCheckFeasibilityOnly (in boolean n) raises (Error);
+        //-> checkFeasibilityOnly
+
+        void setIkSolverInitialization (in IkSolverInitialization solver);
+        //-> ikSolverInitialization
+      }; // interface EET_HERMITE
     }; // module pathPlanner_idl
   }; // module manipulation_idl
 }; // module hpp
@@ -77,5 +100,6 @@ module hpp
 //* #include <hpp/core_idl/path_planners.hh>
 //* #include <hpp/manipulation_idl/_graph-fwd.hh>
 //* #include <hpp/manipulation/roadmap.hh>
+
 
 #endif // HPP_MANIPULATION_CORBA_PATH_PLANNERS_IDL

--- a/idl/hpp/manipulation_idl/steering_methods.idl
+++ b/idl/hpp/manipulation_idl/steering_methods.idl
@@ -50,13 +50,6 @@ module hpp {
         void trajectoryConstraint (in constraints_idl::Implicit c) raises (Error);
         void trajectory (in core_idl::Path eeTraj, in boolean se3Output) raises (Error);
       }; // interface EET_PIECEWISE
-
-      interface EET_HERMITE : core_idl::SteeringMethod
-      {
-        core_idl::Path makePiecewiseLinearTrajectory (in floatSeqSeq points, in floatSeq weights) raises (Error);
-        void trajectoryConstraint (in constraints_idl::Implicit c) raises (Error);
-        void trajectory (in core_idl::Path eeTraj, in boolean se3Output) raises (Error);
-      }; // interface EET_HERMITE
     }; // module steeringMethod
   }; // module manipulation
 }; // module hpp

--- a/idl/hpp/manipulation_idl/steering_methods.idl
+++ b/idl/hpp/manipulation_idl/steering_methods.idl
@@ -44,12 +44,19 @@ module hpp {
   };
   module manipulation_idl {
     module steeringMethod {
-      interface EndEffectorTrajectory : core_idl::SteeringMethod
+      interface EET_PIECEWISE : core_idl::SteeringMethod
       {
         core_idl::Path makePiecewiseLinearTrajectory (in floatSeqSeq points, in floatSeq weights) raises (Error);
         void trajectoryConstraint (in constraints_idl::Implicit c) raises (Error);
         void trajectory (in core_idl::Path eeTraj, in boolean se3Output) raises (Error);
-      }; // interface SteeringMethod
+      }; // interface EET_PIECEWISE
+
+      interface EET_HERMITE : core_idl::SteeringMethod
+      {
+        core_idl::Path makePiecewiseLinearTrajectory (in floatSeqSeq points, in floatSeq weights) raises (Error);
+        void trajectoryConstraint (in constraints_idl::Implicit c) raises (Error);
+        void trajectory (in core_idl::Path eeTraj, in boolean se3Output) raises (Error);
+      }; // interface EET_HERMITE
     }; // module steeringMethod
   }; // module manipulation
 }; // module hpp


### PR DESCRIPTION
This PR is linked to the PR with the same name of HPP-manipulation.

Basically, the name EndEffectorTrajectory has been replaced by EET_PIECEWISE so the interface works properly with changes in HPP-manipulation.

