### PR TITLE
[_graph.idl] Bind methods GraphComponent::solveLevelByLevel.

### DIFF
--- a/idl/hpp/manipulation_idl/_graph.idl
+++ b/idl/hpp/manipulation_idl/_graph.idl
@@ -68,6 +68,11 @@ module hpp {
         constraints_idl::Implicits numericalCosts () raises (Error);
 
         void resetNumericalConstraints () raises (Error);
+
+        void setSolveLevelByLevel(in boolean input) raises(Error);
+        //-> solveLevelByLevel
+        boolean getSolveLevelByLevel() raises(Error);
+        //-> solveLevelByLevel
       }; // interface GraphComponent
 
       interface StateSelector


### PR DESCRIPTION
This pull request re-introduces a commit that had been first merged into `devel` and then reverted because it caused a failure in the CI. However, this commit is necessary for some applications